### PR TITLE
Add CLI DB option and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*.sqlite
+*.db
+*.log
+venv/
+.env
+*.egg-info/
+# ignore database
+/gist_memory_db/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Gist Memory Agent
+
+Prototype implementation of the Gist Memory Agent using a coarse prototype memory system.
+
+## Features
+
+- CLI interface with `ingest` and `query` commands.
+- Uses ChromaDB for persistent storage of prototypes and memories.
+- Simple identity memory creation engine (pluggable).
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Ingest a memory:
+
+```bash
+python -m gist_memory ingest "Some text to remember"
+```
+
+Query memories:
+
+```bash
+python -m gist_memory query "search text" --top 5
+```
+
+Data is stored in `gist_memory_db` in the current working directory by default.
+Use `--db-dir` to specify a different location:
+
+```bash
+python -m gist_memory --db-dir /tmp/gist_db ingest "hello"
+```

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -1,0 +1,5 @@
+"""Gist Memory Agent package."""
+
+from .cli import cli
+
+__all__ = ["cli"]

--- a/gist_memory/__main__.py
+++ b/gist_memory/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -1,0 +1,41 @@
+import click
+
+from .memory_creation import IdentityMemoryCreator
+from .store import PrototypeStore
+
+
+@click.group()
+@click.option("--db-dir", default="gist_memory_db", help="Directory for database")
+@click.pass_context
+def cli(ctx, db_dir: str):
+    """Gist Memory Agent CLI."""
+    ctx.obj = {"db_dir": db_dir}
+
+
+@cli.command()
+@click.argument("text", nargs=-1)
+@click.pass_context
+def ingest(ctx, text):
+    """Ingest a memory from TEXT."""
+    content = " ".join(text)
+    creator = IdentityMemoryCreator()
+    store = PrototypeStore(path=ctx.obj["db_dir"])
+    mem = store.add_memory(creator.create(content))
+    click.echo(f"Stored memory {mem.id} in prototype {mem.prototype_id}")
+
+
+@cli.command()
+@click.argument("text", nargs=-1)
+@click.option("--top", default=3, help="Number of results")
+@click.pass_context
+def query(ctx, text, top):
+    """Query the store."""
+    content = " ".join(text)
+    store = PrototypeStore(path=ctx.obj["db_dir"])
+    results = store.query(content, n=top)
+    for mem in results:
+        click.echo(f"[{mem.prototype_id}] {mem.text}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/gist_memory/embedder.py
+++ b/gist_memory/embedder.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+class Embedder:
+    """Base embedding interface."""
+
+    def embed(self, text: str) -> np.ndarray:
+        raise NotImplementedError()
+
+
+class RandomEmbedder(Embedder):
+    """Generate a random embedding. Placeholder for real model."""
+
+    def __init__(self, dim: int = 768, seed: int | None = None):
+        self.dim = dim
+        self.rng = np.random.default_rng(seed)
+
+    def embed(self, text: str) -> np.ndarray:
+        return self.rng.random(self.dim)

--- a/gist_memory/memory_creation.py
+++ b/gist_memory/memory_creation.py
@@ -1,0 +1,12 @@
+class MemoryCreator:
+    """Base interface for creating memory text from source text."""
+
+    def create(self, text: str) -> str:
+        raise NotImplementedError()
+
+
+class IdentityMemoryCreator(MemoryCreator):
+    """Return the text unchanged."""
+
+    def create(self, text: str) -> str:
+        return text

--- a/gist_memory/store.py
+++ b/gist_memory/store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional
+
+import chromadb
+import numpy as np
+
+from .embedder import RandomEmbedder
+
+
+def default_chroma_client(path: Optional[str] = None) -> chromadb.Client:
+    """Create a Chroma client using PATH or the CWD."""
+    db_path = path or os.path.join(os.getcwd(), "gist_memory_db")
+    return chromadb.PersistentClient(db_path)
+
+
+@dataclass
+class Memory:
+    id: str
+    text: str
+    prototype_id: str
+
+
+@dataclass
+class Prototype:
+    id: str
+    embedding: np.ndarray
+
+
+class PrototypeStore:
+    def __init__(self, client: Optional[chromadb.Client] = None, *, path: Optional[str] = None, threshold: float = 0.4):
+        """Create a prototype store.
+
+        Parameters
+        ----------
+        client: chromadb.Client | None
+            Pre-initialised Chroma client. If ``None`` a persistent client will
+            be created in ``path``.
+        path: str | None
+            Directory to store the persistent database. Defaults to
+            ``gist_memory_db`` in the current working directory.
+        threshold: float
+            Distance threshold for assigning memories to prototypes.
+        """
+        self.client = client or default_chroma_client(path)
+        self.threshold = threshold
+        self.proto_collection = self.client.get_or_create_collection("prototypes")
+        self.memory_collection = self.client.get_or_create_collection("memories")
+        # Using a local random embedder to avoid network downloads in this prototype
+        self.emb_func = RandomEmbedder().embed
+
+    def add_memory(self, text: str) -> Memory:
+        embed = np.array(self.emb_func(text))
+        # find nearest prototype
+        if self.proto_collection.count() > 0:
+            res = self.proto_collection.query(query_embeddings=[embed], n_results=1)
+            pid = res["ids"][0][0]
+            dist = res["distances"][0][0]
+            if dist > self.threshold:
+                pid = self._create_prototype(embed)
+            else:
+                self._update_prototype(pid, embed)
+        else:
+            pid = self._create_prototype(embed)
+        mid = str(uuid.uuid4())
+        self.memory_collection.add(ids=[mid], embeddings=[embed], metadatas=[{"prototype_id": pid}], documents=[text])
+        return Memory(id=mid, text=text, prototype_id=pid)
+
+    def query(self, text: str, n: int = 5) -> List[Memory]:
+        embed = np.array(self.emb_func(text))
+        res = self.proto_collection.query(query_embeddings=[embed], n_results=n)
+        if not res["ids"]:
+            return []
+        proto_ids = [pid for pid in res["ids"][0]]
+        results = []
+        for pid in proto_ids:
+            mem_res = self.memory_collection.get(where={"prototype_id": pid})
+            for mid, doc in zip(mem_res["ids"], mem_res["documents"]):
+                results.append(Memory(id=mid, text=doc, prototype_id=pid))
+        return results
+
+    def _create_prototype(self, embed: np.ndarray) -> str:
+        pid = str(uuid.uuid4())
+        self.proto_collection.add(ids=[pid], embeddings=[embed])
+        return pid
+
+    def _update_prototype(self, pid: str, embed: np.ndarray, alpha: float = 0.1):
+        proto = self.proto_collection.get(ids=[pid])
+        if not proto["ids"]:
+            self.proto_collection.add(ids=[pid], embeddings=[embed])
+            return
+        old = np.array(proto["embeddings"][0])
+        new = (1 - alpha) * old + alpha * embed
+        self.proto_collection.update(ids=[pid], embeddings=[new])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from click.testing import CliRunner
+from gist_memory.cli import cli
+
+
+def test_cli_ingest_and_query(tmp_path):
+    runner = CliRunner()
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        result = runner.invoke(cli, ["--db-dir", str(tmp_path), "ingest", "hello world"])
+        assert result.exit_code == 0
+        result = runner.invoke(cli, ["--db-dir", str(tmp_path), "query", "hello", "--top", "1"])
+        assert result.exit_code == 0
+    finally:
+        os.chdir(cwd)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gist_memory.store import PrototypeStore
+
+
+def test_add_and_query_memory(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        store = PrototypeStore(path=str(tmp_path))
+        mem = store.add_memory("hello world")
+        results = store.query("hello", n=1)
+        ids = {m.id for m in results}
+        assert mem.id in ids
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- expose `--db-dir` option to control database location
- support `path` parameter when creating a store
- document usage of `--db-dir`
- add unit tests for CLI and store operations

## Testing
- `pytest -q`