### PR TITLE
Add offline embedding model download

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -12,3 +12,9 @@ if [ -f requirements.txt ]; then
     pip3 install --no-cache-dir -r requirements.txt
 fi
 
+# Pre-download the default local embedding model so it is available offline
+python3 - <<'EOF'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("all-MiniLM-L6-v2")
+EOF
+

--- a/README.md
+++ b/README.md
@@ -7,25 +7,31 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 - CLI interface with `ingest` and `query` commands.
 - Uses ChromaDB for persistent storage of prototypes and memories.
 - Simple identity memory creation engine (pluggable).
+- Pluggable embedding backends: random (default), OpenAI, or local sentence-transformer.
 
 ## Usage
 
-Install dependencies:
+Install dependencies (the provided `.codex/setup.sh` script will also install
+them and download the default local embedding model for offline use):
 
 ```bash
 pip install -r requirements.txt
+python - <<'EOF'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("all-MiniLM-L6-v2")
+EOF
 ```
 
 Ingest a memory:
 
 ```bash
-python -m gist_memory ingest "Some text to remember"
+python -m gist_memory ingest "Some text to remember" --embedder openai
 ```
 
 Query memories:
 
 ```bash
-python -m gist_memory query "search text" --top 5
+python -m gist_memory query "search text" --top 5 --embedder local --model-name all-MiniLM-L6-v2
 ```
 
 Data is stored in `gist_memory_db` in the current working directory.

--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,6 @@ This file tracks outstanding work based on `AGENTS.md`.
 
 ## Memory creation and embeddings
 - Support pluggable memory creation engines (LLM summary, chunking, extractive).
-- Replace random embeddings with real local or remote models.
-- Allow locally runnable models as an option.
 
 ## Research and evaluation
 - Benchmark prototype-based retrieval vs raw memory retrieval.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 faiss-cpu
 click
 pytest
+sentence-transformers


### PR DESCRIPTION
## Summary
- download the default sentence-transformers model during setup so offline use works
- document the predownload step in installation instructions

## Testing
- `pytest -q`
