### PR TITLE
Fix local embedder offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Query memories:
 python -m gist_memory query "search text" --top 5 --embedder local --model-name all-MiniLM-L6-v2
 ```
 
+The local embedder loads the model from the Hugging Face cache only and will not
+attempt any network downloads. Ensure the model is pre-cached using the commands
+in the installation section or via `.codex/setup.sh`.
+
 Data is stored in `gist_memory_db` in the current working directory.
 
 ## Running Tests

--- a/gist_memory/embedder.py
+++ b/gist_memory/embedder.py
@@ -42,12 +42,32 @@ class OpenAIEmbedder(Embedder):
 class LocalEmbedder(Embedder):
     """Embed text using a locally runnable SentenceTransformer model."""
 
-    def __init__(self, model_name: str = "all-MiniLM-L6-v2"):
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        *,
+        local_files_only: bool = True,
+    ):
+        """Create a local embedder.
+
+        Parameters
+        ----------
+        model_name:
+            Name or path of the model to load.
+        local_files_only:
+            If ``True`` (the default), disable any network calls and only use
+            locally cached model files. This allows the embedder to function in
+            fully offline environments.
+        """
+
         if SentenceTransformer is None:
             raise ImportError(
                 "sentence-transformers is required for LocalEmbedder"
             )
-        self.model = SentenceTransformer(model_name)
+        self.model = SentenceTransformer(
+            model_name,
+            local_files_only=local_files_only,
+        )
 
     def embed(self, text: str) -> np.ndarray:
         vec = self.model.encode(text)

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -34,7 +34,14 @@ def test_local_embedder(monkeypatch):
         def encode(self, text):
             return [0.3, 0.4, 0.5]
 
-    monkeypatch.setattr(emb, "SentenceTransformer", lambda name: DummyModel())
+    called_kwargs = {}
+
+    def fake_sentence_transformer(name, **kwargs):
+        called_kwargs.update(kwargs)
+        return DummyModel()
+
+    monkeypatch.setattr(emb, "SentenceTransformer", fake_sentence_transformer)
     e = emb.LocalEmbedder(model_name="dummy")
     vec = e.embed("hi")
     assert np.allclose(vec, np.array([0.3, 0.4, 0.5], dtype=np.float32))
+    assert called_kwargs.get("local_files_only") is True


### PR DESCRIPTION
## Summary
- ensure LocalEmbedder only loads models from local cache
- update unit tests for LocalEmbedder
- document offline behaviour in README
- check that SentenceTransformer receives `local_files_only`

## Testing
- `pytest -q`
