### PR TITLE
Add prototype decode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 
 ## Features
 
-- CLI interface with `ingest` and `query` commands.
+ - CLI interface with `ingest`, `query`, `decode`, and `dump` commands.
 - Uses ChromaDB for persistent storage of prototypes and memories.
 - Pluggable memory creation engines (identity or simple extractive summary).
 - Pluggable embedding backends: random (default), OpenAI, or local sentence-transformer.
@@ -34,6 +34,18 @@ Query memories:
 ```bash
 python -m gist_memory query "search text" --top 5 \
     --embedder local --model-name all-MiniLM-L6-v2 --threshold 0.3
+```
+
+Decode a prototype to see example memories:
+
+```bash
+python -m gist_memory decode <prototype_id> --top 2
+```
+
+Dump all memories (optionally filter by prototype):
+
+```bash
+python -m gist_memory dump --prototype-id <prototype_id>
 ```
 
 The local embedder loads the model from the Hugging Face cache only and will not

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -71,5 +71,35 @@ def query(obj, text, top):
         click.echo(f"[{mem.prototype_id}] {mem.text}")
 
 
+@cli.command(name="decode")
+@click.argument("prototype_id")
+@click.option("--top", default=1, help="Number of memories to show")
+@click.pass_obj
+def decode_prototype(obj, prototype_id, top):
+    """Show example memories for a prototype."""
+    store = PrototypeStore(
+        embedder=obj["embedder"], threshold=obj["threshold"]
+    )
+    memories = store.decode_prototype(prototype_id, n=top)
+    if not memories:
+        click.echo("Prototype not found")
+        return
+    for mem in memories:
+        click.echo(f"{mem.id}: {mem.text}")
+
+
+@cli.command(name="dump")
+@click.option("--prototype-id", default=None, help="Only dump memories for this prototype")
+@click.pass_obj
+def dump_memories(obj, prototype_id):
+    """Dump all memories, optionally for a given prototype."""
+    store = PrototypeStore(
+        embedder=obj["embedder"], threshold=obj["threshold"]
+    )
+    memories = store.dump_memories(prototype_id=prototype_id)
+    for mem in memories:
+        click.echo(f"[{mem.prototype_id}] {mem.text}")
+
+
 if __name__ == "__main__":
     cli()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -60,3 +60,24 @@ def test_query_ranking():
     results = store.query("hello", n=1)
     assert len(results) == 1
     assert results[0].text == "hello world"
+
+
+def test_decode_prototype():
+    client = chromadb.EphemeralClient()
+    store = PrototypeStore(client=client)
+    mem = store.add_memory("alpha bravo")
+    mems = store.decode_prototype(mem.prototype_id, n=1)
+    assert mems
+    assert mems[0].text == "alpha bravo"
+
+
+def test_dump_memories():
+    client = chromadb.EphemeralClient()
+    store = PrototypeStore(client=client)
+    mem1 = store.add_memory("foo")
+    mem2 = store.add_memory("bar")
+    all_mems = store.dump_memories()
+    texts = {m.text for m in all_mems}
+    assert {"foo", "bar"}.issubset(texts)
+    filtered = store.dump_memories(prototype_id=mem1.prototype_id)
+    assert any(m.text == "foo" for m in filtered)


### PR DESCRIPTION
## Summary
- implement CLI `decode` command to inspect a prototype
- add `decode_prototype` helper in `PrototypeStore`
- document decode feature in README
- test new decode functionality

## Testing
- `pytest -q`
