### PR TITLE
Add test for ingesting long text

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -81,3 +81,18 @@ def test_dump_memories():
     assert {"foo", "bar"}.issubset(texts)
     filtered = store.dump_memories(prototype_id=mem1.prototype_id)
     assert any(m.text == "foo" for m in filtered)
+
+
+def test_ingest_long_text_end_state():
+    text = """Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.
+
+Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived and so dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting place for those who here gave their lives that that nation might live. It is altogether fitting and proper that we should do this.
+
+But, in a larger sense, we can not dedicate -- we can not consecrate -- we can not hallow -- this ground. The brave men, living and dead, who struggled here, have consecrated it, far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us -- that from these honored dead we take increased devotion to that cause for which they gave the last full measure of devotion -- that we here highly resolve that these dead shall not have died in vain -- that this nation, under God, shall have a new birth of freedom -- and that government of the people, by the people, for the people, shall not perish from the earth."""
+
+    client = chromadb.EphemeralClient()
+    store = PrototypeStore(client=client)
+    mem = store.add_memory(text)
+
+    all_mems = store.dump_memories()
+    assert any(m.id == mem.id and m.text == text for m in all_mems)


### PR DESCRIPTION
## Summary
- validate ingestion and storage of long text via a new test case
- use triple-quoted string for clarity

## Testing
- `pytest -q`