### PR TITLE
Add file and directory ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ python -m gist_memory ingest "Some text to remember" \
     --embedder openai --memory-creator extractive --threshold 0.3
 ```
 
+You can also pass a path to a text file or a directory containing ``*.txt``
+files:
+
+```bash
+python -m gist_memory ingest notes.txt
+python -m gist_memory ingest docs/
+```
+
 Query memories:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import chromadb
+from click.testing import CliRunner
+
+from gist_memory.cli import cli
+from gist_memory.store import PrototypeStore
+
+
+def _patch_client(monkeypatch, client):
+    import gist_memory.store as store_module
+    monkeypatch.setattr(store_module, "default_chroma_client", lambda: client)
+
+
+def test_cli_ingest_file(tmp_path, monkeypatch):
+    file_path = tmp_path / "one.txt"
+    file_path.write_text("hello world")
+    client = chromadb.EphemeralClient()
+    _patch_client(monkeypatch, client)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ingest", str(file_path)])
+    assert result.exit_code == 0
+
+    store = PrototypeStore(client=client)
+    mems = store.dump_memories()
+    assert any(m.text == "hello world" for m in mems)
+
+
+def test_cli_ingest_directory(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("alpha")
+    (tmp_path / "b.txt").write_text("bravo")
+    client = chromadb.EphemeralClient()
+    _patch_client(monkeypatch, client)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ingest", str(tmp_path)])
+    assert result.exit_code == 0
+
+    store = PrototypeStore(client=client)
+    mems = store.dump_memories()
+    texts = {m.text for m in mems}
+    assert {"alpha", "bravo"}.issubset(texts)


### PR DESCRIPTION
## Summary
- allow `ingest` command to accept a path to a text file or directory
- document the new usage in README
- add CLI tests for file and directory ingestion

## Testing
- `pytest -q`