### PR TITLE
Add onboarding demo with moon landing transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,27 @@ Install development dependencies and run `pytest`:
 pip install -r requirements.txt
 pytest
 ```
+
+## Onboarding Demo
+
+A small example is provided under `examples/` so new users can quickly see the
+agent in action.  The demo ingests short excerpts from the Apollo&nbsp;11 moon
+landing transcripts and prints which prototypes were created or updated.
+
+Run the demo after installing dependencies and pre-downloading the local
+embedding model:
+
+```bash
+pip install -r requirements.txt
+python - <<'PY'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("all-MiniLM-L6-v2")
+PY
+
+# run the example
+python examples/onboarding_demo.py
+```
+
+The script loads all `*.txt` files from `examples/moon_landing`, stores them in a
+local database and displays the prototype assignments along with a final memory
+and prototype count.

--- a/examples/moon_landing/01_landing.txt
+++ b/examples/moon_landing/01_landing.txt
@@ -1,0 +1,1 @@
+Houston, Tranquility Base here. The Eagle has landed.

--- a/examples/moon_landing/02_first_step.txt
+++ b/examples/moon_landing/02_first_step.txt
@@ -1,0 +1,1 @@
+That's one small step for man, one giant leap for mankind.

--- a/examples/moon_landing/03_eagle.txt
+++ b/examples/moon_landing/03_eagle.txt
@@ -1,0 +1,1 @@
+We copy you down, Eagle.

--- a/examples/moon_landing/04_rocks.txt
+++ b/examples/moon_landing/04_rocks.txt
@@ -1,0 +1,1 @@
+Armstrong: Looks like a collection of just about every variety of rock you can find.

--- a/examples/onboarding_demo.py
+++ b/examples/onboarding_demo.py
@@ -1,0 +1,29 @@
+"""Simple onboarding demo for Gist Memory."""
+from pathlib import Path
+
+from gist_memory.store import PrototypeStore
+from gist_memory.memory_creation import IdentityMemoryCreator
+from gist_memory.embedder import get_embedder
+
+
+def main() -> None:
+    folder = Path(__file__).parent / "moon_landing"
+    texts = [p.read_text() for p in sorted(folder.glob("*.txt"))]
+
+    store = PrototypeStore(embedder=get_embedder("local", "all-MiniLM-L6-v2"))
+    creator = IdentityMemoryCreator()
+
+    for text in texts:
+        before = store.proto_collection.count()
+        mem = store.add_memory(creator.create(text))
+        after = store.proto_collection.count()
+        action = "Created" if after > before else "Updated"
+        print(f"{action} prototype {mem.prototype_id} with memory {mem.id}")
+
+    print()
+    print(f"Total memories: {store.memory_collection.count()}")
+    print(f"Total prototypes: {store.proto_collection.count()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small Apollo 11 transcript dataset under `examples/`
- provide an onboarding demonstration script that ingests the dataset
- document demo usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`