### PR TITLE
Add CLI model download command

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -13,8 +13,5 @@ if [ -f requirements.txt ]; then
 fi
 
 # Pre-download the default local embedding model so it is available offline
-python3 - <<'EOF'
-from sentence_transformers import SentenceTransformer
-SentenceTransformer("all-MiniLM-L6-v2")
-EOF
+python3 -m gist_memory download-model --model-name all-MiniLM-L6-v2
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,15 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 
 ## Setup
 
-This project requires **Python 3.11+**.  Install the dependencies and pre-cache
-the default local embedding model:
+This project requires **Python 3.11+**.  Install the dependencies and download
+the default local embedding model (only needed the first time):
 
 ```bash
 pip install -r requirements.txt
-python - <<'EOF'
-from sentence_transformers import SentenceTransformer
-SentenceTransformer("all-MiniLM-L6-v2")
-EOF
+# fetch the "all-MiniLM-L6-v2" model so the local embedder works offline
+python -m gist_memory download-model --model-name all-MiniLM-L6-v2
 
-You can alternatively run `.codex/setup.sh` which performs the same steps.
+# You can alternatively run `.codex/setup.sh` to perform these steps.
 ```
 
 Alternatively install the package from source:
@@ -95,10 +93,8 @@ embedding model:
 
 ```bash
 pip install -r requirements.txt
-python - <<'PY'
-from sentence_transformers import SentenceTransformer
-SentenceTransformer("all-MiniLM-L6-v2")
-PY
+# download the local model once
+python -m gist_memory download-model --model-name all-MiniLM-L6-v2
 
 # run the example
 python examples/onboarding_demo.py

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -6,7 +6,7 @@ from .memory_creation import (
     ExtractiveSummaryCreator,
 )
 from .store import PrototypeStore
-from .embedder import get_embedder
+from .embedder import get_embedder, LocalEmbedder
 
 
 @click.group()
@@ -117,6 +117,22 @@ def dump_memories(obj, prototype_id):
     memories = store.dump_memories(prototype_id=prototype_id)
     for mem in memories:
         click.echo(f"[{mem.prototype_id}] {mem.text}")
+
+
+@cli.command(name="download-model")
+@click.option(
+    "--model-name",
+    default="all-MiniLM-L6-v2",
+    show_default=True,
+    help="Embedding model to pre-download",
+)
+def download_model(model_name: str) -> None:
+    """Pre-fetch a local embedding model."""
+    try:
+        LocalEmbedder(model_name=model_name, local_files_only=False)
+    except Exception as exc:  # pragma: no cover - passthrough
+        raise click.ClickException(str(exc))
+    click.echo(f"Downloaded model '{model_name}'")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def _patch_client(monkeypatch, client):
 def test_cli_ingest_file(tmp_path, monkeypatch):
     file_path = tmp_path / "one.txt"
     file_path.write_text("hello world")
-    client = chromadb.EphemeralClient()
+    client = chromadb.PersistentClient(str(tmp_path / "db_file"))
     _patch_client(monkeypatch, client)
 
     runner = CliRunner()
@@ -23,12 +23,15 @@ def test_cli_ingest_file(tmp_path, monkeypatch):
     store = PrototypeStore(client=client)
     mems = store.dump_memories()
     assert any(m.text == "hello world" for m in mems)
+    # cleanup database
+    import shutil
+    shutil.rmtree(str(tmp_path / "db_file"))
 
 
 def test_cli_ingest_directory(tmp_path, monkeypatch):
     (tmp_path / "a.txt").write_text("alpha")
     (tmp_path / "b.txt").write_text("bravo")
-    client = chromadb.EphemeralClient()
+    client = chromadb.PersistentClient(str(tmp_path / "db_file"))
     _patch_client(monkeypatch, client)
 
     runner = CliRunner()
@@ -39,3 +42,25 @@ def test_cli_ingest_directory(tmp_path, monkeypatch):
     mems = store.dump_memories()
     texts = {m.text for m in mems}
     assert {"alpha", "bravo"}.issubset(texts)
+    import shutil
+    shutil.rmtree(str(tmp_path / "db_file"))
+
+
+def test_cli_download_model(monkeypatch):
+    called = {}
+
+    def fake_local_embedder(model_name="", local_files_only=True):
+        called["name"] = model_name
+        called["offline"] = local_files_only
+        class Dummy:
+            pass
+        return Dummy()
+
+    import importlib
+    cli_module = importlib.import_module("gist_memory.cli")
+    monkeypatch.setattr(cli_module, "LocalEmbedder", fake_local_embedder)
+
+    runner = CliRunner()
+    res = runner.invoke(cli, ["download-model", "--model-name", "foo"])
+    assert res.exit_code == 0
+    assert called == {"name": "foo", "offline": False}


### PR DESCRIPTION
## Summary
- add `download-model` command to CLI
- update instructions in README and setup script
- use persistent DB for CLI tests and add test for new command

## Testing
- `pytest -q`