### PR TITLE
Enhance memory creators and prototype summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 
 ## Features
 
- - CLI interface with `ingest`, `query`, `decode`, and `dump` commands.
-- Uses ChromaDB for persistent storage of prototypes and memories.
-- Pluggable memory creation engines (identity or simple extractive summary).
+ - CLI interface with `ingest`, `query`, `decode`, `summarize`, and `dump` commands.
+ - Uses ChromaDB for persistent storage of prototypes and memories.
+ - Pluggable memory creation engines (identity, extractive, chunk, or LLM summary).
 - Pluggable embedding backends: random (default), OpenAI, or local sentence-transformer.
 
 ## Setup
@@ -34,7 +34,8 @@ Ingest a memory:
 
 ```bash
 python -m gist_memory ingest "Some text to remember" \
-    --embedder openai --memory-creator extractive --threshold 0.3
+    --embedder openai --memory-creator extractive --threshold 0.3 \
+    --min-threshold 0.05 --decay-exponent 0.5
 ```
 
 When using the OpenAI embedder, set the ``OPENAI_API_KEY`` environment
@@ -59,6 +60,12 @@ Decode a prototype to see example memories:
 
 ```bash
 python -m gist_memory decode <prototype_id> --top 2
+```
+
+Summarize a prototype:
+
+```bash
+python -m gist_memory summarize <prototype_id> --max-words 20
 ```
 
 Dump all memories (optionally filter by prototype):

--- a/TODO.md
+++ b/TODO.md
@@ -3,15 +3,15 @@
 This file tracks outstanding work based on `AGENTS.md`.
 
 ## Prototype memory system
- - Update prototypes via EMA and add health checks for splitting or merging.
-- Implement memory/prototype decay and conflict resolution flows.
+ - Update prototypes via EMA and add health checks for splitting or merging. *(partial: EMA implemented, health checks pending)*
+- Implement memory/prototype decay and conflict resolution flows. *(pending)*
 
 ## Retrieval pipeline
-- Add two-tier retrieval with fine re-ranking or raw memory lookup.
-- Provide decoding of prototypes into human-readable summaries.
+- Add two-tier retrieval with fine re-ranking or raw memory lookup. *(done)*
+- Provide decoding of prototypes into human-readable summaries. *(done)*
 
 ## Memory creation and embeddings
-- Support pluggable memory creation engines (LLM summary, chunking, extractive).
+- Support pluggable memory creation engines (LLM summary, chunking, extractive). *(done)*
 
 ## Research and evaluation
 - Benchmark prototype-based retrieval vs raw memory retrieval.
@@ -20,7 +20,7 @@ This file tracks outstanding work based on `AGENTS.md`.
 - Evaluate methods for decoding prototype meaning.
 
 ## CLI and usability
-- Expose configuration options (threshold, embedding model, memory creator).
-- Allow configuration of adaptive threshold parameters.
-- Improve documentation and installation instructions.
+- Expose configuration options (threshold, embedding model, memory creator). *(done)*
+- Allow configuration of adaptive threshold parameters. *(done)*
+- Improve documentation and installation instructions. *(done)*
 

--- a/tests/test_memory_creation.py
+++ b/tests/test_memory_creation.py
@@ -1,6 +1,8 @@
 from gist_memory.memory_creation import (
     IdentityMemoryCreator,
     ExtractiveSummaryCreator,
+    ChunkMemoryCreator,
+    LLMSummaryCreator,
 )
 
 
@@ -14,3 +16,21 @@ def test_extractive_summary_creator():
     creator = ExtractiveSummaryCreator(max_words=3)
     text = "one two three four five"
     assert creator.create(text) == "one two three"
+
+
+def test_chunk_memory_creator():
+    creator = ChunkMemoryCreator(chunk_size=2)
+    text = "one two three four"
+    chunks = creator.create_all(text)
+    assert chunks == ["one two", "three four"]
+
+
+def test_llm_summary_creator(monkeypatch):
+    class Dummy:
+        @staticmethod
+        def create(*args, **kwargs):
+            return {"choices": [{"message": {"content": "summary"}}]}
+    import openai
+    monkeypatch.setattr(openai.ChatCompletion, "create", Dummy.create)
+    creator = LLMSummaryCreator(model="dummy")
+    assert creator.create("text") == "summary"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -71,6 +71,14 @@ def test_decode_prototype():
     assert mems[0].text == "alpha bravo"
 
 
+def test_summarize_prototype():
+    client = chromadb.EphemeralClient()
+    store = PrototypeStore(client=client)
+    mem1 = store.add_memory("alpha bravo charlie")
+    summary = store.summarize_prototype(mem1.prototype_id, max_words=2)
+    assert summary == "alpha bravo"
+
+
 def test_dump_memories():
     client = chromadb.EphemeralClient()
     store = PrototypeStore(client=client)


### PR DESCRIPTION
## Summary
- add chunk and LLM memory creators
- expose adaptive threshold parameters on the CLI
- support summarizing prototypes via new CLI command
- allow memory creators to return multiple segments
- document new features and update TODO list
- test new creators and summary helpers

## Testing
- `pytest -q`