### PR TITLE
Add interactive Textual TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 - Pluggable memory creation engines (identity, extractive, chunk, LLM summary, or agentic splitting).
 - Pluggable embedding backends: random (default), OpenAI, or local sentence-transformer.
 - Ingest operation displays a progress bar showing which prototypes are created or updated.
+- Launches a simple Textual TUI when running `gist-memory` with no arguments.
 
 ## Setup
 
@@ -30,6 +31,18 @@ pip install .
 ```
 
 ## Usage
+
+### Interactive TUI
+
+Run ``gist-memory`` with no arguments to start an in-terminal interface that
+allows you to pick a ``.txt`` file from the current directory or enter text
+manually for ingestion:
+
+```bash
+gist-memory
+```
+
+### Command line
 
 Ingest a memory:
 

--- a/gist_memory/__main__.py
+++ b/gist_memory/__main__.py
@@ -1,4 +1,20 @@
-from .cli import cli
+import sys
+
+
+def main(argv=None) -> None:
+    """Entry point for the ``gist-memory`` command.
+
+    When invoked without arguments, launch the Textual TUI. Otherwise fall back
+    to the CLI implementation.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) == 0:
+        from .tui import run_tui
+        run_tui()
+    else:
+        from .cli import cli
+        cli()
+
 
 if __name__ == "__main__":
-    cli()
+    main()

--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -1,0 +1,60 @@
+"""Simple Textual-based TUI for ingesting text files or manual input."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .memory_creation import IdentityMemoryCreator
+from .store import PrototypeStore
+
+
+def run_tui() -> None:
+    """Launch the Textual TUI."""
+    try:
+        from textual.app import App, ComposeResult
+        from textual.widgets import Header, Footer, Label, Input, ListView, ListItem
+        from textual.containers import Container
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("Textual is required for the TUI") from exc
+
+    class IngestApp(App):
+        """Basic ingestion interface."""
+
+        CSS_PATH = None
+
+        def compose(self) -> ComposeResult:  # type: ignore[override]
+            yield Header()
+            yield Label("Select a .txt file or press i to type text", id="hint")
+            files = [f for f in Path('.').glob('*.txt')]
+            items = [ListItem(Label(f.name), id=str(f)) for f in files]
+            yield ListView(*items, id="files")
+            yield Input(placeholder="enter text", id="input", classes="hidden")
+            yield Label("", id="status")
+            yield Footer()
+
+        def on_list_view_selected(self, event: ListView.Selected) -> None:
+            path = Path(event.item.id)
+            text = path.read_text()
+            self._ingest(text)
+
+        def key_i(self) -> None:
+            inp = self.query_one("#input", Input)
+            inp.remove_class("hidden")
+            inp.focus()
+
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            self._ingest(event.value)
+            event.input.value = ""
+            event.input.add_class("hidden")
+
+        def _ingest(self, text: str) -> None:
+            store = PrototypeStore()
+            creator = IdentityMemoryCreator()
+            for chunk in creator.create_all(text):
+                mem = store.add_memory(chunk)
+            status = self.query_one("#status", Label)
+            status.update("Ingested text")
+
+    IngestApp().run()
+
+
+__all__ = ["run_tui"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,11 @@ dependencies = [
     "click",
     "tqdm",
     "sentence-transformers",
+    "textual",
 ]
 
 [project.optional-dependencies]
 test = ["pytest"]
 
 [project.scripts]
-gist-memory = "gist_memory.cli:cli"
+gist-memory = "gist_memory.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ click
 tqdm
 pytest
 sentence-transformers
+textual

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,28 @@
+import importlib
+from types import SimpleNamespace
+
+import gist_memory.__main__ as main_mod
+
+
+def test_main_uses_tui_when_no_args(monkeypatch):
+    called = {}
+    monkeypatch.setattr(main_mod, "sys", SimpleNamespace(argv=["gist-memory"]))
+    importlib.reload(main_mod)
+    tui_mod = importlib.import_module("gist_memory.tui")
+    cli_mod = importlib.import_module("gist_memory.cli")
+    monkeypatch.setattr(tui_mod, "run_tui", lambda: called.setdefault("tui", True))
+    monkeypatch.setattr(cli_mod, "cli", lambda: called.setdefault("cli", True))
+    main_mod.main([])
+    assert called == {"tui": True}
+
+
+def test_main_uses_cli_with_args(monkeypatch):
+    called = {}
+    monkeypatch.setattr(main_mod, "sys", SimpleNamespace(argv=["gist-memory", "ingest"]))
+    importlib.reload(main_mod)
+    tui_mod = importlib.import_module("gist_memory.tui")
+    cli_mod = importlib.import_module("gist_memory.cli")
+    monkeypatch.setattr(tui_mod, "run_tui", lambda: called.setdefault("tui", True))
+    monkeypatch.setattr(cli_mod, "cli", lambda: called.setdefault("cli", True))
+    main_mod.main(["ingest"])
+    assert called == {"cli": True}


### PR DESCRIPTION
## Summary
- integrate simple Textual UI for ingesting text
- add new ``gist_memory.tui`` module
- switch ``gist-memory`` entrypoint to launch TUI when no arguments are passed
- document TUI usage in the README
- include a small unit test for the new behaviour

## Testing
- `pytest -q`