### PR TITLE
Include Typer and portalocker in setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -14,8 +14,8 @@ else
     pip3 install --no-cache-dir textual
 fi
 
-# Ensure textual is available even when not listed in requirements
-pip3 install --no-cache-dir textual
+# Ensure CLI dependencies are available even when not listed in requirements
+pip3 install --no-cache-dir textual typer portalocker
 
 # Pre-download the default local embedding model so it is available offline
 python3 -m gist_memory download-model --model-name all-MiniLM-L6-v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "sentence-transformers",
     "textual",
     "nltk",
+    "typer[all]",
+    "portalocker",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pytest
 sentence-transformers
 textual  # required for the TUI
 nltk
+typer[all]
+portalocker


### PR DESCRIPTION
## Summary
- add `typer` and `portalocker` to the project dependencies
- install CLI requirements explicitly in setup script

## Testing
- `pytest -q`