### PR TITLE
Implement query API and Typer CLI

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -1,6 +1,6 @@
 """Gist Memory Agent package."""
 
-from .cli import cli
+from .cli import app
 from .models import BeliefPrototype, RawMemory
 from .json_npy_store import JsonNpyVectorStore, VectorStore
 from .agent import Agent
@@ -8,7 +8,7 @@ from .embedding_pipeline import embed_text
 from .chunker import SentenceWindowChunker, FixedSizeChunker
 
 __all__ = [
-    "cli",
+    "app",
     "BeliefPrototype",
     "RawMemory",
     "JsonNpyVectorStore",

--- a/gist_memory/__main__.py
+++ b/gist_memory/__main__.py
@@ -10,10 +10,12 @@ def main(argv=None) -> None:
     args = sys.argv[1:] if argv is None else argv
     if len(args) == 0:
         from .tui import run_tui
+
         run_tui()
     else:
-        from .cli import cli
-        cli()
+        from .cli import app
+
+        app()
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,18 +11,20 @@ def test_main_uses_tui_when_no_args(monkeypatch):
     tui_mod = importlib.import_module("gist_memory.tui")
     cli_mod = importlib.import_module("gist_memory.cli")
     monkeypatch.setattr(tui_mod, "run_tui", lambda: called.setdefault("tui", True))
-    monkeypatch.setattr(cli_mod, "cli", lambda: called.setdefault("cli", True))
+    monkeypatch.setattr(cli_mod, "app", lambda: called.setdefault("cli", True))
     main_mod.main([])
     assert called == {"tui": True}
 
 
 def test_main_uses_cli_with_args(monkeypatch):
     called = {}
-    monkeypatch.setattr(main_mod, "sys", SimpleNamespace(argv=["gist-memory", "ingest"]))
+    monkeypatch.setattr(
+        main_mod, "sys", SimpleNamespace(argv=["gist-memory", "ingest"])
+    )
     importlib.reload(main_mod)
     tui_mod = importlib.import_module("gist_memory.tui")
     cli_mod = importlib.import_module("gist_memory.cli")
     monkeypatch.setattr(tui_mod, "run_tui", lambda: called.setdefault("tui", True))
-    monkeypatch.setattr(cli_mod, "cli", lambda: called.setdefault("cli", True))
+    monkeypatch.setattr(cli_mod, "app", lambda: called.setdefault("cli", True))
     main_mod.main(["ingest"])
     assert called == {"cli": True}


### PR DESCRIPTION
## Summary
- add `QueryResult` dataclass and `Agent.query()` implementation
- replace click CLI with Typer-based CLI and new commands
- adapt `__main__` entrypoint and package exports
- update CLI and main tests for new interface

## Testing
- `pytest -q`