### PR TITLE
Add gist-run TUI and update query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ pip install .
 
 ### Interactive TUI
 
-Run ``gist-memory`` with no arguments to start an in-terminal interface that
-allows you to pick a ``.txt`` file from the current directory or enter text
-manually for ingestion:
+Install the optional TUI extras and launch ``gist-run`` to explore a brain
+interactively:
 
 ```bash
-gist-memory
+pip install "gist-memory[tui]"
+gist-run
 ```
 
 ### Command line

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -3,7 +3,7 @@
 from .cli import app
 from .models import BeliefPrototype, RawMemory
 from .json_npy_store import JsonNpyVectorStore, VectorStore
-from .agent import Agent
+from .agent import Agent, QueryResult, PrototypeHit, MemoryHit
 from .embedding_pipeline import embed_text
 from .chunker import SentenceWindowChunker, FixedSizeChunker
 
@@ -14,6 +14,9 @@ __all__ = [
     "JsonNpyVectorStore",
     "VectorStore",
     "Agent",
+    "QueryResult",
+    "PrototypeHit",
+    "MemoryHit",
     "embed_text",
     "SentenceWindowChunker",
     "FixedSizeChunker",

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -1,6 +1,5 @@
 import json
 import shutil
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -115,13 +114,13 @@ def query(
             query_text, top_k_prototypes=k_prototypes, top_k_memories=k_memories
         )
     if json_output:
-        typer.echo(json.dumps(asdict(res)))
+        typer.echo(json.dumps(res))
         return
-    for proto in res.prototypes:
+    for proto in res["prototypes"]:
         console.print(
             f"[bold]{proto['id']}[/bold] {proto['summary']} ({proto['sim']:.2f})"
         )
-    for mem in res.memories:
+    for mem in res["memories"]:
         console.print(f"  {mem['text']} ({mem['sim']:.2f})")
 
 

--- a/gist_tui/__main__.py
+++ b/gist_tui/__main__.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gist_memory.agent import Agent
+from gist_memory.json_npy_store import JsonNpyVectorStore
+
+
+def main(path: str = "brain") -> None:
+    """Run the simple Gist Memory TUI."""
+    try:
+        from textual.app import App, ComposeResult
+        from textual.widgets import Header, Footer, Input, TextLog
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError("textual is required for gist-run") from exc
+
+    store_path = Path(path)
+    store = JsonNpyVectorStore(path=str(store_path))
+    agent = Agent(store)
+
+    class GistApp(App):
+        CSS_PATH = None
+        BINDINGS = [
+            ("ctrl+i", "show_ingest", "Ingest"),
+            ("ctrl+q", "show_query", "Query"),
+            ("q", "quit", "Quit"),
+        ]
+
+        def compose(self) -> ComposeResult:  # type: ignore[override]
+            self.ingest = Input(placeholder="add text and press enter", id="ingest")
+            self.query = Input(placeholder="ask a question and press enter", id="query", classes="hidden")
+            self.log = TextLog()
+            yield Header()
+            yield self.ingest
+            yield self.query
+            yield self.log
+            yield Footer()
+
+        def action_show_ingest(self) -> None:
+            self.ingest.remove_class("hidden")
+            self.query.add_class("hidden")
+            self.ingest.focus()
+
+        def action_show_query(self) -> None:
+            self.query.remove_class("hidden")
+            self.ingest.add_class("hidden")
+            self.query.focus()
+
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            if event.input.id == "ingest":
+                res = agent.add_memory(event.value)
+                self.log.write_line(f"added {len(res)} chunk(s)")
+                event.input.value = ""
+            else:
+                res = agent.query(event.value, top_k_prototypes=3, top_k_memories=3)
+                for p in res["prototypes"]:
+                    self.log.write_line(f"{p['sim']:.2f} {p['summary']}")
+                for m in res["memories"]:
+                    self.log.write_line(f"  {m['text']}")
+                event.input.value = ""
+
+    GistApp().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "pydantic",
     "pyyaml",
     "sentence-transformers",
-    "textual",
     "nltk",
     "typer[all]",
     "portalocker",
@@ -29,6 +28,8 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 chroma = ["chromadb"]
+tui = ["textual>=0.46", "rich>=13.6"]
 
 [project.scripts]
 gist-memory = "gist_memory.__main__:main"
+gist-run = "gist_tui.__main__:main"


### PR DESCRIPTION
## Summary
- replace `QueryResult` dataclass with TypedDict API
- remove `asdict` use in CLI and access dict entries directly
- provide a small Textual front-end under `gist_tui` and new `gist-run` script
- expose new classes via `__init__` and document TUI usage in README
- add optional `tui` extras with textual and rich

## Testing
- `pytest -q`