### PR TITLE
Enable TUI by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ pip install .
 
 ### Interactive TUI
 
-Install the optional TUI extras and launch ``gist-run`` to explore a brain
-interactively:
+Launch ``gist-run`` to explore a brain interactively:
 
 ```bash
-pip install "gist-memory[tui]"
 gist-run
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "nltk",
     "typer[all]",
     "portalocker",
+    "textual>=0.46",
+    "rich>=13.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- include TUI dependencies in the default installation
- simplify README instructions for launching `gist-run`

## Testing
- `pytest -q`