### PR TITLE
Fix TUI for Textual 3.x

### DIFF
--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -32,14 +32,11 @@ def run_tui(path: str = "brain") -> None:
         from textual.app import App, ComposeResult
         from textual.containers import Container
         from textual.screen import Screen
-        from textual.widgets import (
-            Header,
-            Footer,
-            Static,
-            Input,
-            TextLog,
-            DataTable,
-        )
+        from textual.widgets import Header, Footer, Static, Input, DataTable
+        try:  # Textual 0.x
+            from textual.widgets import TextLog  # type: ignore
+        except Exception:  # pragma: no cover - Textual >=1.0 renamed the widget
+            from textual.widgets import Log as TextLog  # type: ignore
     except Exception as exc:  # pragma: no cover - optional dependency
         raise RuntimeError("Textual is required for the TUI") from exc
 

--- a/gist_tui/__main__.py
+++ b/gist_tui/__main__.py
@@ -10,7 +10,11 @@ def main(path: str = "brain") -> None:
     """Run the simple Gist Memory TUI."""
     try:
         from textual.app import App, ComposeResult
-        from textual.widgets import Header, Footer, Input, TextLog
+        from textual.widgets import Header, Footer, Input
+        try:
+            from textual.widgets import TextLog  # type: ignore
+        except Exception:
+            from textual.widgets import Log as TextLog  # type: ignore
     except Exception as exc:  # pragma: no cover
         raise RuntimeError("textual is required for gist-run") from exc
 


### PR DESCRIPTION
## Summary
- fix gist_memory TUI for newer Textual versions
- update `gist-run` to detect Textual 3.x as well

## Testing
- `pytest -q`