### PR TITLE
Fix local embedding on macOS

### DIFF
--- a/examples/onboarding_demo.py
+++ b/examples/onboarding_demo.py
@@ -1,9 +1,13 @@
 """Simple onboarding demo for Gist Memory."""
 from pathlib import Path
+import os
 
 from gist_memory.store import PrototypeStore
 from gist_memory.memory_creation import IdentityMemoryCreator
 from gist_memory.embedder import get_embedder
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 
 def main() -> None:
@@ -14,15 +18,15 @@ def main() -> None:
     creator = IdentityMemoryCreator()
 
     for text in texts:
-        before = store.proto_collection.count()
+        before = store.prototype_count()
         mem = store.add_memory(creator.create(text))
-        after = store.proto_collection.count()
+        after = store.prototype_count()
         action = "Created" if after > before else "Updated"
         print(f"{action} prototype {mem.prototype_id} with memory {mem.id}")
 
     print()
-    print(f"Total memories: {store.memory_collection.count()}")
-    print(f"Total prototypes: {store.proto_collection.count()}")
+    print(f"Total memories: {len(store.memories)}")
+    print(f"Total prototypes: {store.prototype_count()}")
 
 
 if __name__ == "__main__":

--- a/gist_memory/embedding_pipeline.py
+++ b/gist_memory/embedding_pipeline.py
@@ -4,6 +4,21 @@ import functools
 import hashlib
 from typing import List, Sequence
 
+# ---------------------------------------------------------------------------
+# Disable tqdm's multiprocessing lock.
+# On some platforms (notably macOS with the "spawn" start method) creating
+# the default multiprocessing lock can fail with "ValueError: bad value(s) in
+# fds_to_keep".  Avoid this by monkeypatching tqdm to skip the mp lock.
+try:  # pragma: no cover - only needed on certain platforms
+    import tqdm.std
+
+    def _no_mp_lock(cls):
+        cls.mp_lock = None
+
+    tqdm.std.TqdmDefaultWriteLock.create_mp_lock = classmethod(_no_mp_lock)
+except Exception:  # pragma: no cover - tqdm not installed or different API
+    pass
+
 import numpy as np
 
 try:  # optional heavy deps


### PR DESCRIPTION
## Summary
- monkeypatch tqdm to avoid spawning mp locks
- run onboarding demo fully offline and use generic APIs

## Testing
- `pytest -q`
- `PYTHONPATH=. python examples/onboarding_demo.py`