### PR TITLE
Introduce default brain location

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Launch ``gist-run`` to explore a brain interactively:
 gist-run
 ```
 
+All commands operate on the ``brain`` directory by default. Pass
+``--agent-name`` (or a directory argument for ``gist init``) to use a
+different location.
+
 ### Command line
 
 Ingest a memory:
@@ -93,7 +97,7 @@ The local embedder loads the model from the Hugging Face cache only and will not
 attempt any network downloads. Ensure the model is pre-cached using the commands
 in the setup section or via `.codex/setup.sh`.
 
-Data is stored in `gist_memory_db` in the current working directory.
+Data is stored in the `brain` directory by default in the current working directory.
 
 ## Scaling with Chroma
 

--- a/examples/onboarding_demo.py
+++ b/examples/onboarding_demo.py
@@ -5,6 +5,7 @@ import os
 from gist_memory.store import PrototypeStore
 from gist_memory.memory_creation import IdentityMemoryCreator
 from gist_memory.embedder import get_embedder
+from gist_memory.config import DEFAULT_BRAIN_PATH
 
 os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
@@ -14,7 +15,10 @@ def main() -> None:
     folder = Path(__file__).parent / "moon_landing"
     texts = [p.read_text() for p in sorted(folder.glob("*.txt"))]
 
-    store = PrototypeStore(embedder=get_embedder("local", "all-MiniLM-L6-v2"))
+    store = PrototypeStore(
+        path=DEFAULT_BRAIN_PATH,
+        embedder=get_embedder("local", "all-MiniLM-L6-v2"),
+    )
     creator = IdentityMemoryCreator()
 
     for text in texts:

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -6,6 +6,7 @@ from .json_npy_store import JsonNpyVectorStore, VectorStore
 from .agent import Agent, QueryResult, PrototypeHit, MemoryHit
 from .embedding_pipeline import embed_text
 from .chunker import SentenceWindowChunker, FixedSizeChunker
+from .config import DEFAULT_BRAIN_PATH
 
 __all__ = [
     "app",
@@ -20,6 +21,7 @@ __all__ = [
     "embed_text",
     "SentenceWindowChunker",
     "FixedSizeChunker",
+    "DEFAULT_BRAIN_PATH",
 ]
 
 # Semantic version of the package

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -12,6 +12,7 @@ from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
 from .chunker import SentenceWindowChunker, _CHUNKER_REGISTRY
 from .embedding_pipeline import embed_text
+from .config import DEFAULT_BRAIN_PATH
 
 app = typer.Typer(help="Gist Memory command line interface")
 console = Console()
@@ -40,7 +41,7 @@ def _load_agent(path: Path) -> Agent:
 
 @app.command()
 def init(
-    directory: str,
+    directory: str = typer.Argument(DEFAULT_BRAIN_PATH),
     *,
     agent_name: str = "default",
     model_name: str = "all-MiniLM-L6-v2",
@@ -72,7 +73,9 @@ def init(
 @app.command()
 def add(
     *,
-    agent_name: str = typer.Option(..., help="Path to the agent directory"),
+    agent_name: str = typer.Option(
+        DEFAULT_BRAIN_PATH, help="Path to the agent directory"
+    ),
     text: Optional[str] = typer.Option(None, help="Text to add"),
     file: Optional[Path] = typer.Option(None, help="Text file to add"),
     source_id: Optional[str] = typer.Option(None, help="Source id"),
@@ -100,7 +103,7 @@ def add(
 @app.command()
 def query(
     *,
-    agent_name: str = typer.Option(..., help="Agent directory"),
+    agent_name: str = typer.Option(DEFAULT_BRAIN_PATH, help="Agent directory"),
     query_text: str = typer.Option(..., help="Query text"),
     k_prototypes: int = typer.Option(1, help="Number of prototypes"),
     k_memories: int = typer.Option(3, help="Number of memories"),
@@ -126,7 +129,7 @@ def query(
 
 @app.command("list-beliefs")
 def list_beliefs(
-    agent_name: str = typer.Argument(..., help="Agent directory"),
+    agent_name: str = typer.Argument(DEFAULT_BRAIN_PATH, help="Agent directory"),
     sort: str = typer.Option("", help="Sort order"),
 ) -> None:
     """List all belief prototypes."""
@@ -148,7 +151,7 @@ def list_beliefs(
 
 @app.command()
 def stats(
-    agent_name: str = typer.Argument(..., help="Agent directory"),
+    agent_name: str = typer.Argument(DEFAULT_BRAIN_PATH, help="Agent directory"),
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
 ) -> None:
     """Show statistics about the store."""

--- a/gist_memory/config.py
+++ b/gist_memory/config.py
@@ -1,0 +1,5 @@
+"""Shared configuration constants."""
+
+DEFAULT_BRAIN_PATH = "brain"
+
+__all__ = ["DEFAULT_BRAIN_PATH"]

--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional
 
 from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
+from .config import DEFAULT_BRAIN_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +27,7 @@ def _disk_usage(path: Path) -> int:
 
 # ---------------------------------------------------------------------------
 
-def run_tui(path: str = "brain") -> None:
+def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
     """Launch the Textual wizard."""
     try:
         from textual.app import App, ComposeResult

--- a/gist_tui/__main__.py
+++ b/gist_tui/__main__.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 from gist_memory.agent import Agent
 from gist_memory.json_npy_store import JsonNpyVectorStore
+from gist_memory.config import DEFAULT_BRAIN_PATH
 
 
-def main(path: str = "brain") -> None:
+def main(path: str = DEFAULT_BRAIN_PATH) -> None:
     """Run the simple Gist Memory TUI."""
     try:
         from textual.app import App, ComposeResult


### PR DESCRIPTION
## Summary
- set up `DEFAULT_BRAIN_PATH` constant
- default CLI, TUIs and demo to use the `brain` directory
- document the default location in the README

## Testing
- `pytest -q`