### PR TITLE
Fix TUI screen names for Textual 3

### DIFF
--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -220,6 +220,15 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
             ("q", "push_screen('exit')", "Quit"),
         ]
 
+        SCREENS = {
+            "help": HelpScreen(),
+            "ingest": IngestScreen(),
+            "beliefs": BeliefScreen(),
+            "query": QueryScreen(),
+            "stats": StatsScreen(),
+            "exit": ExitScreen(),
+        }
+
         def on_mount(self) -> None:
             self.push_screen(WelcomeScreen())
 
@@ -227,15 +236,6 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
             if isinstance(event.screen, ExitScreen):
                 return
             store.save()
-
-    WizardApp.screens = {
-        "help": HelpScreen(),
-        "ingest": IngestScreen(),
-        "beliefs": BeliefScreen(),
-        "query": QueryScreen(),
-        "stats": StatsScreen(),
-        "exit": ExitScreen(),
-    }
 
     WizardApp().run()
 


### PR DESCRIPTION
## Summary
- register wizard screens using `SCREENS` so Textual 3 can find them
- keep functionality the same but avoid `No screen called` errors

## Testing
- `pytest -q`