### PR TITLE
Add helpful message when model is missing

### DIFF
--- a/gist_memory/embedding_pipeline.py
+++ b/gist_memory/embedding_pipeline.py
@@ -63,7 +63,13 @@ def _load_model(model_name: str, device: str) -> SentenceTransformer:
     if _MODEL is None or model_name != _MODEL_NAME or device != _DEVICE:
         if torch is not None:
             torch.manual_seed(0)
-        _MODEL = SentenceTransformer(model_name, device=device)
+        try:
+            _MODEL = SentenceTransformer(model_name, device=device)
+        except Exception as exc:  # pragma: no cover - depends on local files
+            raise RuntimeError(
+                "Embedding model not found. "
+                "Run `gist-memory download-model` to install it"
+            ) from exc
         _MODEL_NAME = model_name
         _DEVICE = device
     return _MODEL

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -1,5 +1,6 @@
 import numpy as np
 import importlib
+import pytest
 
 from gist_memory import embedding_pipeline as ep
 
@@ -20,3 +21,13 @@ def test_embed_text_uses_mock(monkeypatch):
     exp = enc.encode("a")
     exp = exp / np.linalg.norm(exp)
     assert np.allclose(vecs[0], exp)
+
+
+def test_load_model_failure(monkeypatch):
+    def raise_err(*a, **k):
+        raise OSError("missing")
+
+    monkeypatch.setattr(ep, "SentenceTransformer", raise_err)
+    with pytest.raises(RuntimeError) as exc:
+        ep._load_model("bad", "cpu")
+    assert "gist-memory download-model" in str(exc.value)


### PR DESCRIPTION
## Summary
- handle missing local `SentenceTransformer` models more gracefully
- test the new behaviour in the embedding pipeline

## Testing
- `pytest -q`