### PR TITLE
Add pluggable TemplateBuilder class

### DIFF
--- a/gist_memory/memory_creation.py
+++ b/gist_memory/memory_creation.py
@@ -88,6 +88,42 @@ class AgenticMemoryCreator(MemoryCreator):
         )
 
 
+_TEMPLATE_REGISTRY: dict[str, type["TemplateBuilder"]] = {}
+
+
+def register_template_builder(id: str, cls: type["TemplateBuilder"]) -> None:
+    _TEMPLATE_REGISTRY[id] = cls
+
+
+class TemplateBuilder:
+    """Combine extracted slots with a sentence into a canonical string."""
+
+    id: str = "default"
+
+    def build(self, sentence: str, slots: dict[str, str]) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def config(self) -> dict[str, int | str]:
+        return {"id": self.id}
+
+
+class DefaultTemplateBuilder(TemplateBuilder):
+    """Simple builder concatenating slot values."""
+
+    id = "default"
+
+    def build(self, sentence: str, slots: dict[str, str]) -> str:
+        parts = [sentence]
+        for key in ("who", "what", "when", "where", "why"):
+            val = slots.get(key)
+            if val:
+                parts.append(f"{key}:{val}")
+        return " | ".join(parts)
+
+
+register_template_builder(DefaultTemplateBuilder.id, DefaultTemplateBuilder)
+
+
 __all__ = [
     "MemoryCreator",
     "IdentityMemoryCreator",
@@ -95,4 +131,8 @@ __all__ = [
     "ChunkMemoryCreator",
     "LLMSummaryCreator",
     "AgenticMemoryCreator",
+    "TemplateBuilder",
+    "DefaultTemplateBuilder",
+    "register_template_builder",
+    "_TEMPLATE_REGISTRY",
 ]

--- a/tests/test_memory_creation.py
+++ b/tests/test_memory_creation.py
@@ -3,6 +3,10 @@ from gist_memory.memory_creation import (
     ExtractiveSummaryCreator,
     ChunkMemoryCreator,
     LLMSummaryCreator,
+    TemplateBuilder,
+    DefaultTemplateBuilder,
+    register_template_builder,
+    _TEMPLATE_REGISTRY,
 )
 
 
@@ -43,3 +47,22 @@ def test_llm_summary_creator(monkeypatch):
     monkeypatch.setattr(openai.ChatCompletion, "create", Dummy.create)
     creator = LLMSummaryCreator(model="dummy")
     assert creator.create("text") == "summary"
+
+
+def test_default_template_builder():
+    builder = DefaultTemplateBuilder()
+    out = builder.build("hello", {"who": "Alice", "why": "testing"})
+    assert "hello" in out
+    assert "who:Alice" in out
+    assert "why:testing" in out
+
+
+def test_register_template_builder():
+    class DummyTemplate(TemplateBuilder):
+        id = "dummy"
+
+        def build(self, sentence: str, slots: dict[str, str]) -> str:
+            return "dummy"
+
+    register_template_builder(DummyTemplate.id, DummyTemplate)
+    assert _TEMPLATE_REGISTRY["dummy"] is DummyTemplate


### PR DESCRIPTION
## Summary
- add `TemplateBuilder` with registry in `memory_creation.py`
- include default implementation and export
- test default builder and registration

## Testing
- `pytest -q`