### PR TITLE
Add chat model predownload

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -19,4 +19,6 @@ pip3 install --no-cache-dir textual rich typer portalocker
 
 # Pre-download the default local embedding model so it is available offline
 python3 -m gist_memory download-model --model-name all-MiniLM-L6-v2
+# Pre-download the default chat model for talk mode
+python3 -m gist_memory download-chat-model --model-name distilgpt2
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ the default local embedding model (only needed the first time):
 pip install -r requirements.txt
 # fetch the "all-MiniLM-L6-v2" model so the local embedder works offline
 gist-memory download-model --model-name all-MiniLM-L6-v2
+# fetch the default chat model for talk mode
+gist-memory download-chat-model --model-name distilgpt2
 ```
 
 For a quick offline setup you can also run:
@@ -85,6 +87,7 @@ Chat with the entire brain using a local model:
 ```bash
 gist-memory talk --message "What's in this brain?"
 ```
+Ensure the chat model is pre-downloaded using `gist-memory download-chat-model`.
 
 List belief prototypes and show store stats:
 
@@ -100,8 +103,8 @@ Additional functions such as decoding or summarising a prototype are
 available via the Python API.
 
 The local embedder loads the model from the Hugging Face cache only and will not
-attempt any network downloads. Ensure the model is pre-cached using the commands
-in the setup section or via `.codex/setup.sh`.
+attempt any network downloads. Ensure the embedding and chat models are
+pre-cached using the commands in the setup section or via `.codex/setup.sh`.
 
 Data is stored in the `brain` directory by default in the current working directory.
 

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -253,5 +253,19 @@ def download_model(
     typer.echo(f"Downloaded {model_name}")
 
 
+@app.command("download-chat-model")
+def download_chat_model(
+    model_name: str = typer.Option(
+        "distilgpt2", help="Local causal LM name"
+    )
+) -> None:
+    """Pre-download a local chat model for ``talk`` mode."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    AutoTokenizer.from_pretrained(model_name)
+    AutoModelForCausalLM.from_pretrained(model_name)
+    typer.echo(f"Downloaded {model_name}")
+
+
 if __name__ == "__main__":
     app()

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -22,12 +22,19 @@ class LocalChatModel:
     def __post_init__(self) -> None:
         if AutoModelForCausalLM is None or AutoTokenizer is None:
             raise ImportError("transformers is required for LocalChatModel")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, local_files_only=True
-        )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.model_name, local_files_only=True
-        )
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self.model_name, local_files_only=True
+            )
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_name, local_files_only=True
+            )
+        except Exception as exc:  # pragma: no cover - depends on local files
+            raise RuntimeError(
+                "Chat model not found. "
+                "Run `gist-memory download-chat-model --model-name "
+                f"{self.model_name}` to install it"
+            ) from exc
 
     def reply(self, prompt: str) -> str:
         """Generate a reply given ``prompt``."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,3 +101,26 @@ def test_cli_talk(tmp_path, monkeypatch):
     assert "hello world" in prompts["text"]
 
 
+def test_cli_download_chat_model(monkeypatch):
+    runner = CliRunner()
+
+    calls = []
+
+    class Dummy:
+        @staticmethod
+        def from_pretrained(name, **kw):
+            calls.append(name)
+            return Dummy()
+
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained", Dummy.from_pretrained
+    )
+    monkeypatch.setattr(
+        "transformers.AutoModelForCausalLM.from_pretrained", Dummy.from_pretrained
+    )
+
+    result = runner.invoke(app, ["download-chat-model", "--model-name", "foo"])
+    assert result.exit_code == 0
+    assert "foo" in calls
+
+


### PR DESCRIPTION
## Summary
- provide `download-chat-model` command to fetch local LLM
- handle missing chat model gracefully
- document chat model download in the README and setup script
- test the new CLI command

## Testing
- `pytest -q`