### PR TITLE
Fix timezone and Pydantic warnings

### DIFF
--- a/gist_memory/models.py
+++ b/gist_memory/models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class BeliefPrototype(BaseModel):
@@ -14,23 +14,23 @@ class BeliefPrototype(BaseModel):
     summary_text: str = Field(default="")
     strength: float = 1.0
     confidence: float = 1.0
-    creation_ts: datetime = Field(default_factory=lambda: datetime.utcnow().replace(microsecond=0))
-    last_updated_ts: datetime = Field(default_factory=lambda: datetime.utcnow().replace(microsecond=0))
+    creation_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
+    last_updated_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
     constituent_memory_ids: List[str] = Field(default_factory=list)
 
-    @validator("summary_text")
+    @field_validator("summary_text")
     def _limit_summary(cls, v: str) -> str:
         if len(v) > 256:
             return v[:256]
         return v
 
-    @validator("strength")
+    @field_validator("strength")
     def _check_strength(cls, v: float) -> float:
         if v <= 0:
             raise ValueError("strength must be > 0")
         return v
 
-    @validator("confidence")
+    @field_validator("confidence")
     def _check_confidence(cls, v: float) -> float:
         if not 0 <= v <= 1:
             raise ValueError("confidence must be between 0 and 1")
@@ -44,6 +44,6 @@ class RawMemory(BaseModel):
     raw_text_hash: str
     assigned_prototype_id: Optional[str] = None
     source_document_id: Optional[str] = None
-    creation_ts: datetime = Field(default_factory=lambda: datetime.utcnow().replace(microsecond=0))
+    creation_ts: datetime = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
     raw_text: str
     embedding: Optional[List[float]] = None

--- a/tests/test_json_store.py
+++ b/tests/test_json_store.py
@@ -1,5 +1,5 @@
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 from gist_memory.json_npy_store import JsonNpyVectorStore
 from gist_memory.models import BeliefPrototype, RawMemory
@@ -14,8 +14,8 @@ def test_json_npy_roundtrip(tmp_path):
         summary_text="test",
         strength=1.0,
         confidence=1.0,
-        creation_ts=datetime.utcnow(),
-        last_updated_ts=datetime.utcnow(),
+        creation_ts=datetime.now(timezone.utc),
+        last_updated_ts=datetime.now(timezone.utc),
     )
     store.add_prototype(proto, np.array([1.0, 0.0, 0.0], dtype=np.float32))
     mem = RawMemory(
@@ -44,8 +44,8 @@ def test_meta_validation(tmp_path):
         summary_text="a",
         strength=1.0,
         confidence=1.0,
-        creation_ts=datetime.utcnow(),
-        last_updated_ts=datetime.utcnow(),
+        creation_ts=datetime.now(timezone.utc),
+        last_updated_ts=datetime.now(timezone.utc),
     )
     store.add_prototype(proto, np.array([0.0, 1.0, 0.0], dtype=np.float32))
     store.save()


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(timezone.utc)`
- update pydantic validators to `field_validator`
- load JSONL with `model_validate_json`
- adjust tests to use timezone-aware datetimes

## Testing
- `pytest -q`