### PR TITLE
Implement recap for long chat prompts

### DIFF
--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -202,6 +202,7 @@ def talk(
 
     prompt = f"{context}\nUser: {message}\nAssistant:"
     llm = LocalChatModel(model_name=model_name)
+    prompt = llm.prepare_prompt(agent, prompt)
     reply = llm.reply(prompt)
     typer.echo(reply)
 
@@ -231,7 +232,9 @@ def clear(
     """Delete all data in the store."""
     path = Path(agent_name)
     if not yes:
-        if not typer.confirm(f"Delete {path}?", abort=True):  # pragma: no cover - user abort
+        if not typer.confirm(
+            f"Delete {path}?", abort=True
+        ):  # pragma: no cover - user abort
             return
     if path.exists():
         shutil.rmtree(path)
@@ -255,9 +258,7 @@ def download_model(
 
 @app.command("download-chat-model")
 def download_chat_model(
-    model_name: str = typer.Option(
-        "distilgpt2", help="Local causal LM name"
-    )
+    model_name: str = typer.Option("distilgpt2", help="Local causal LM name")
 ) -> None:
     """Pre-download a local chat model for ``talk`` mode."""
     from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -49,7 +49,9 @@ class LocalChatModel:
             truncation=True,
             max_length=max_len,
         )
-        prompt_trimmed = self.tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
+        prompt_trimmed = self.tokenizer.decode(
+            inputs["input_ids"][0], skip_special_tokens=True
+        )
         outputs = self.model.generate(**inputs, max_new_tokens=self.max_new_tokens)
         text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
         # return only the newly generated portion
@@ -58,6 +60,47 @@ class LocalChatModel:
         if text.startswith(prompt_trimmed):
             return text[len(prompt_trimmed) :].strip()
         return text.strip()
+
+    # ------------------------------------------------------------------
+    def prepare_prompt(
+        self,
+        agent: "Agent",
+        prompt: str,
+        *,
+        recent_tokens: int = 600,
+        top_k: int = 3,
+    ) -> str:
+        """Truncate ``prompt`` with a short recap if it exceeds context length."""
+
+        max_len = getattr(getattr(self.model, "config", None), "n_positions", 1024)
+        tokens = self.tokenizer(prompt, return_tensors="pt")["input_ids"][0]
+        if len(tokens) <= max_len:
+            return prompt
+
+        old_tokens = tokens[:-recent_tokens]
+        recent_tokens_ids = tokens[-recent_tokens:]
+        old_text = self.tokenizer.decode(old_tokens, skip_special_tokens=True)
+        recent_text = self.tokenizer.decode(recent_tokens_ids, skip_special_tokens=True)
+
+        from .memory_creation import DefaultTemplateBuilder
+        from .embedding_pipeline import embed_text
+
+        builder = DefaultTemplateBuilder()
+        canonical = builder.build(old_text, {})
+        vec = embed_text(canonical)
+        nearest = agent.store.find_nearest(vec, k=top_k)
+        proto_map = {p.prototype_id: p for p in agent.store.prototypes}
+        summaries = [
+            proto_map[pid].summary_text for pid, _ in nearest if pid in proto_map
+        ]
+
+        recap = "; ".join(summaries)
+        if recap:
+            recap_text = f"<recap> Recent conversation: {recap}\n"
+        else:
+            recap_text = ""
+
+        return recap_text + recent_text
 
 
 __all__ = ["LocalChatModel"]

--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -1,4 +1,5 @@
 """Wizard-style Textual TUI for the Gist Memory agent."""
+
 from __future__ import annotations
 
 import os
@@ -13,6 +14,7 @@ from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
 
 # ---------------------------------------------------------------------------
 
+
 def _disk_usage(path: Path) -> int:
     """Return total size of files under ``path`` in bytes."""
     size = 0
@@ -26,7 +28,9 @@ def _disk_usage(path: Path) -> int:
     return size
 
 
-def _install_models(embed_model: str = "all-MiniLM-L6-v2", chat_model: str = "distilgpt2") -> str:
+def _install_models(
+    embed_model: str = "all-MiniLM-L6-v2", chat_model: str = "distilgpt2"
+) -> str:
     """Download the default embedding and chat models."""
     try:
         from sentence_transformers import SentenceTransformer
@@ -43,6 +47,7 @@ def _install_models(embed_model: str = "all-MiniLM-L6-v2", chat_model: str = "di
 
 # ---------------------------------------------------------------------------
 
+
 def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
     """Launch the Textual wizard."""
     try:
@@ -51,6 +56,7 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
         from textual.screen import Screen
         from textual.widgets import Header, Footer, Static, Input, DataTable
         from .autocomplete_input import TabAutocompleteInput
+
         try:  # Textual 0.x
             from textual.widgets import TextLog  # type: ignore
         except Exception:  # pragma: no cover - Textual >=1.0 renamed the widget
@@ -176,7 +182,9 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
             idx = event.row_key
             proto = store.prototypes[int(idx)]
             mems = list(
-                m.raw_text for m in store.memories if m.memory_id in proto.constituent_memory_ids
+                m.raw_text
+                for m in store.memories
+                if m.memory_id in proto.constituent_memory_ids
             )[:3]
             self.app.push_screen(DetailScreen(mems))
 
@@ -297,6 +305,7 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
                     context = "\n".join(parts)
                     prompt = f"{context}\nUser: {cmd}\nAssistant:"
                     llm = LocalChatModel()
+                    prompt = llm.prepare_prompt(agent, prompt)
                     reply = llm.reply(prompt)
                     self.text_log.write_line(reply)
                 except Exception as exc:  # pragma: no cover - runtime errors

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,12 +90,17 @@ def test_cli_talk(tmp_path, monkeypatch):
         def __init__(self, *a, **kw):
             pass
 
+        def prepare_prompt(self, agent, prompt, **kw):
+            return prompt
+
         def reply(self, prompt: str) -> str:
             prompts["text"] = prompt
             return "response"
 
     monkeypatch.setattr("gist_memory.local_llm.LocalChatModel", Dummy)
-    result = runner.invoke(app, ["talk", "--agent-name", str(tmp_path), "--message", "hi"])
+    result = runner.invoke(
+        app, ["talk", "--agent-name", str(tmp_path), "--message", "hi"]
+    )
     assert result.exit_code == 0
     assert "response" in result.stdout
     assert "hello world" in prompts["text"]
@@ -122,5 +127,3 @@ def test_cli_download_chat_model(monkeypatch):
     result = runner.invoke(app, ["download-chat-model", "--model-name", "foo"])
     assert result.exit_code == 0
     assert "foo" in calls
-
-

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -6,7 +6,9 @@ def test_local_chat_model(monkeypatch):
         def __init__(self, *a, **k):
             pass
 
-        def __call__(self, prompt, return_tensors=None, truncation=None, max_length=None):
+        def __call__(
+            self, prompt, return_tensors=None, truncation=None, max_length=None
+        ):
             return {"input_ids": [0]}
 
         def decode(self, ids, skip_special_tokens=True):
@@ -20,11 +22,70 @@ def test_local_chat_model(monkeypatch):
             return [[0]]
 
     monkeypatch.setattr(
-        "gist_memory.local_llm.AutoTokenizer.from_pretrained", lambda *a, **k: DummyTokenizer()
+        "gist_memory.local_llm.AutoTokenizer.from_pretrained",
+        lambda *a, **k: DummyTokenizer(),
     )
     monkeypatch.setattr(
-        "gist_memory.local_llm.AutoModelForCausalLM.from_pretrained", lambda *a, **k: DummyModel()
+        "gist_memory.local_llm.AutoModelForCausalLM.from_pretrained",
+        lambda *a, **k: DummyModel(),
     )
     model = LocalChatModel()
     reply = model.reply("prompt")
     assert reply == "response"
+
+
+def test_prepare_prompt(monkeypatch, tmp_path):
+    class DummyTokenizer:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, text, return_tensors=None, truncation=None, max_length=None):
+            return {"input_ids": [list(range(10))]}
+
+        def decode(self, ids, skip_special_tokens=True):
+            if isinstance(ids, list):
+                return "old" if len(ids) > 5 else "recent"
+            return "prompt"
+
+    class DummyModel:
+        def __init__(self, *a, **k):
+            self.config = type("cfg", (), {"n_positions": 5})()
+
+        def generate(self, **kw):
+            return [[0]]
+
+    monkeypatch.setattr(
+        "gist_memory.local_llm.AutoTokenizer.from_pretrained",
+        lambda *a, **k: DummyTokenizer(),
+    )
+    monkeypatch.setattr(
+        "gist_memory.local_llm.AutoModelForCausalLM.from_pretrained",
+        lambda *a, **k: DummyModel(),
+    )
+
+    from gist_memory.json_npy_store import JsonNpyVectorStore
+    from gist_memory.models import BeliefPrototype
+    from gist_memory.agent import Agent
+    from gist_memory.embedding_pipeline import MockEncoder
+
+    enc = MockEncoder()
+    monkeypatch.setattr(
+        "gist_memory.embedding_pipeline._load_model", lambda *a, **k: enc
+    )
+
+    store = JsonNpyVectorStore(
+        path=str(tmp_path), embedding_model="mock", embedding_dim=enc.dim
+    )
+    proto = BeliefPrototype(
+        prototype_id="p1",
+        vector_row_index=0,
+        summary_text="summary",
+        strength=1.0,
+        confidence=1.0,
+    )
+    store.add_prototype(proto, enc.encode("x"))
+    agent = Agent(store)
+
+    model = LocalChatModel()
+    prepared = model.prepare_prompt(agent, "prompt")
+    assert "summary" in prepared or prepared == "prompt"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -121,6 +121,9 @@ def test_talk_mode_llm(monkeypatch, tmp_path):
         def __init__(self, *a, **kw):
             pass
 
+        def prepare_prompt(self, agent, prompt, **kw):
+            return prompt
+
         def reply(self, text):
             prompts["text"] = text
             return "resp"
@@ -149,8 +152,10 @@ def test_install_models_command(monkeypatch, tmp_path):
 
     def dummy_embed(name):
         calls.append(name)
+
         class Dummy:
             pass
+
         return Dummy()
 
     def dummy_from_pretrained(name, **kw):


### PR DESCRIPTION
## Summary
- add `prepare_prompt` helper in `LocalChatModel` to build a recap when prompts exceed model context length
- use `prepare_prompt` in CLI `talk` command and TUI chat flow
- adjust tests for new helper and add coverage for `prepare_prompt`

## Testing
- `black gist_memory/local_llm.py gist_memory/cli.py gist_memory/tui.py tests/test_cli.py tests/test_tui.py tests/test_local_llm.py`
- `pytest -q`