### PR TITLE
Add MemoryCueRenderer and update talk mode

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -9,6 +9,7 @@ from .chunker import SentenceWindowChunker, FixedSizeChunker
 from .config import DEFAULT_BRAIN_PATH
 from .local_llm import LocalChatModel
 from .canonical import render_five_w_template
+from .memory_cues import MemoryCueRenderer
 
 __all__ = [
     "app",
@@ -26,6 +27,7 @@ __all__ = [
     "DEFAULT_BRAIN_PATH",
     "LocalChatModel",
     "render_five_w_template",
+    "MemoryCueRenderer",
 ]
 
 # Semantic version of the package

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -13,6 +13,7 @@ from .json_npy_store import JsonNpyVectorStore
 from .chunker import SentenceWindowChunker, _CHUNKER_REGISTRY
 from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
 from .config import DEFAULT_BRAIN_PATH
+from .memory_cues import MemoryCueRenderer
 
 app = typer.Typer(help="Gist Memory command line interface")
 console = Console()
@@ -188,12 +189,16 @@ def talk(
     model_name: str = typer.Option("distilgpt2", help="Local chat model"),
 ) -> None:
     """Talk to the brain using a local LLM."""
-    from .local_llm import LocalChatModel
 
     path = Path(agent_name)
     with PersistenceLock(path):
         agent = _load_agent(path)
-        parts = []
+        # render short memory cue tags for the most relevant prototypes
+        q = agent.query(message, top_k_prototypes=3, top_k_memories=0)
+        cue_renderer = MemoryCueRenderer()
+        cues = cue_renderer.render([p["summary"] for p in q["prototypes"]])
+
+        parts = [cues] if cues else []
         for proto in agent.store.prototypes:
             parts.append(f"{proto.prototype_id}: {proto.summary_text}")
         for mem in agent.store.memories:
@@ -201,6 +206,7 @@ def talk(
         context = "\n".join(parts)
 
     prompt = f"{context}\nUser: {message}\nAssistant:"
+    from .local_llm import LocalChatModel
     llm = LocalChatModel(model_name=model_name)
     reply = llm.reply(prompt)
     typer.echo(reply)

--- a/gist_memory/memory_cues.py
+++ b/gist_memory/memory_cues.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Render inline memory cues for prototypes."""
+
+import re
+from typing import Iterable
+
+
+class MemoryCueRenderer:
+    """Convert prototype summaries into short ``<MEM id=... />`` tags."""
+
+    def __init__(self, max_words: int = 2) -> None:
+        self.max_words = max_words
+
+    def _slug(self, text: str) -> str:
+        words = re.findall(r"[A-Za-z0-9]+", text)[: self.max_words]
+        if not words:
+            words = ["mem"]
+        return "_".join(words)
+
+    def tag(self, summary: str) -> str:
+        return f"<MEM id={self._slug(summary)} />"
+
+    def render(self, summaries: Iterable[str]) -> str:
+        return " ".join(self.tag(s) for s in summaries)
+
+
+__all__ = ["MemoryCueRenderer"]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ def test_cli_talk(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "response" in result.stdout
     assert "hello world" in prompts["text"]
+    assert "<MEM" in prompts["text"]
 
 
 def test_cli_download_chat_model(monkeypatch):

--- a/tests/test_memory_cues.py
+++ b/tests/test_memory_cues.py
@@ -1,0 +1,9 @@
+from gist_memory.memory_cues import MemoryCueRenderer
+
+
+def test_memory_cue_renderer_basic():
+    renderer = MemoryCueRenderer(max_words=2)
+    cues = renderer.render(["Budget 2025 planning", "Alpha Beta Gamma"])
+    assert "<MEM id=Budget_2025 />" in cues
+    assert "<MEM id=Alpha_Beta />" in cues
+

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -139,7 +139,9 @@ def test_talk_mode_llm(monkeypatch, tmp_path):
     _patch_run(monkeypatch, autopilot)
     run_tui(str(tmp_path))
 
-    assert "hi" in prompts.get("text", "")
+    txt = prompts.get("text", "")
+    assert "hi" in txt
+    assert "<MEM" in txt
 
 
 def test_install_models_command(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `MemoryCueRenderer` for prototype cue tags
- integrate memory cues into CLI and TUI talk prompts
- export `MemoryCueRenderer` in package init
- test the cue renderer and updated talk behaviour

## Testing
- `pytest -q`