### PR TITLE
Fix leftover import conflict

### DIFF
--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -19,7 +19,6 @@ from .json_npy_store import JsonNpyVectorStore
 from .chunker import SentenceWindowChunker, _CHUNKER_REGISTRY
 from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
 from .config import DEFAULT_BRAIN_PATH
-from .memory_cues import MemoryCueRenderer
 
 app = typer.Typer(help="Gist Memory command line interface")
 console = Console()


### PR DESCRIPTION
## Summary
- remove duplicate MemoryCueRenderer import

## Testing
- `pytest -q tests/test_cli.py::test_cli_logging -q` *(fails: openaipublic connection attempt)*