### PR TITLE
Add conflict logging and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 - Python API provides helpers to decode and summarise prototypes.
 - Chat with a brain using a local LLM via the `talk` command.
 - Enable debug logging with `--log-file` or the `/log` TUI command.
+- Conflicts are heuristically flagged and written to `conflicts.jsonl` for
+  HITL review.
 
 ## Setup
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,7 +77,9 @@ They are stored in JSON and referenced by ID in the NPY vector arrays.
    spawns a new prototype.
 4. **Updating** – existing prototypes are updated using an exponential
    moving average. New memories are appended to the JSON lines file and
-   evidence is logged in `evidence.jsonl`.
+   evidence is logged in `evidence.jsonl`. Potential contradictions
+   detected via a simple negation check are appended to
+   `conflicts.jsonl` for human review.
 
 The agent keeps an LRU cache of recent SHA‑256 hashes to skip duplicates
 quickly.

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -10,6 +10,7 @@ from .config import DEFAULT_BRAIN_PATH
 from .local_llm import LocalChatModel
 from .canonical import render_five_w_template
 from .memory_cues import MemoryCueRenderer
+from .conflict import ConflictLogger, negation_conflict
 
 __all__ = [
     "app",
@@ -28,6 +29,8 @@ __all__ = [
     "LocalChatModel",
     "render_five_w_template",
     "MemoryCueRenderer",
+    "ConflictLogger",
+    "negation_conflict",
 ]
 
 # Semantic version of the package

--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -21,6 +21,7 @@ from .memory_creation import (
     MemoryCreator,
 )
 from .canonical import render_five_w_template
+from .conflict import ConflictLogger, negation_conflict
 
 
 class VectorIndexCorrupt(RuntimeError):
@@ -123,9 +124,25 @@ class Agent:
         self._dedup = _LRUSet(size=dedup_cache)
         if isinstance(store.path, (str, Path)):
             p = Path(store.path) / "evidence.jsonl"
+            c = Path(store.path) / "conflicts.jsonl"
         else:
             p = Path("evidence.jsonl")
+            c = Path("conflicts.jsonl")
         self._evidence = EvidenceWriter(p)
+        self._conflicts = ConflictLogger(c)
+
+    # ------------------------------------------------------------------
+    def _log_conflict(self, proto_id: str, mem_a: RawMemory, mem_b: RawMemory) -> None:
+        self._conflicts.add(proto_id, mem_a, mem_b)
+
+    def _check_conflicts(self, proto_id: str, new_mem: RawMemory) -> None:
+        for mem in self.store.memories:
+            if mem.memory_id == new_mem.memory_id:
+                continue
+            if mem.assigned_prototype_id != proto_id:
+                continue
+            if negation_conflict(mem.raw_text, new_mem.raw_text):
+                self._log_conflict(proto_id, mem, new_mem)
 
     # ------------------------------------------------------------------
     def _write_evidence(self, belief_id: str, mem_id: str, weight: float) -> None:
@@ -201,6 +218,7 @@ class Agent:
             )
             self.store.add_memory(raw_mem)
             self._write_evidence(pid, mem_id, 1.0)
+            self._check_conflicts(pid, raw_mem)
             self.metrics["memories_ingested"] += 1
             if self.update_summaries:
                 texts = [

--- a/gist_memory/conflict.py
+++ b/gist_memory/conflict.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Simple conflict detection and logging utilities."""
+
+import json
+import re
+from pathlib import Path
+
+from .models import RawMemory
+
+
+# naive regex for "X is Y" / "X is not Y" style statements
+_PATTERN = re.compile(r"^\s*(.+?)\s+is\s+(not\s+)?(.+?)\.?\s*$", re.IGNORECASE)
+
+
+def negation_conflict(text_a: str, text_b: str) -> bool:
+    """Return ``True`` if ``text_a`` contradicts ``text_b`` by simple negation."""
+    ma = _PATTERN.match(text_a)
+    mb = _PATTERN.match(text_b)
+    if not ma or not mb:
+        return False
+    subj_a, neg_a, obj_a = ma.group(1).strip().lower(), bool(ma.group(2)), ma.group(3).strip().lower()
+    subj_b, neg_b, obj_b = mb.group(1).strip().lower(), bool(mb.group(2)), mb.group(3).strip().lower()
+    return subj_a == subj_b and obj_a == obj_b and neg_a != neg_b
+
+
+class ConflictLogger:
+    """Append conflicts to ``conflicts.jsonl`` for HITL review."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def add(self, prototype_id: str, mem_a: RawMemory, mem_b: RawMemory) -> None:
+        with open(self.path, "a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "prototype_id": prototype_id,
+                        "memory_id_a": mem_a.memory_id,
+                        "memory_id_b": mem_b.memory_id,
+                        "text_a": mem_a.raw_text,
+                        "text_b": mem_b.raw_text,
+                    }
+                )
+                + "\n"
+            )
+
+
+__all__ = ["negation_conflict", "ConflictLogger"]

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+from gist_memory import Agent
+from gist_memory.json_npy_store import JsonNpyVectorStore
+from gist_memory.embedding_pipeline import MockEncoder, _load_model
+from gist_memory.chunker import SentenceWindowChunker
+
+
+@pytest.fixture(autouse=True)
+def use_mock_encoder(monkeypatch):
+    enc = MockEncoder()
+    monkeypatch.setattr("gist_memory.embedding_pipeline._load_model", lambda *a, **k: enc)
+    yield
+
+
+def test_negation_conflict_logging(tmp_path, monkeypatch):
+    store = JsonNpyVectorStore(path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim)
+    agent = Agent(store, chunker=SentenceWindowChunker())
+    agent.add_memory("Alice is happy.")
+    pid = store.prototypes[0].prototype_id
+    monkeypatch.setattr(store, "find_nearest", lambda vec, k=1: [(pid, 1.0)])
+    agent.add_memory("Alice is not happy.")
+    log_path = tmp_path / "conflicts.jsonl"
+    assert log_path.exists()
+    rows = [json.loads(l) for l in log_path.read_text().splitlines() if l.strip()]
+    assert len(rows) == 1
+    assert rows[0]["prototype_id"] == pid


### PR DESCRIPTION
## Summary
- detect simple negation conflicts when ingesting memories
- log conflicts to conflicts.jsonl
- expose conflict utilities in public API
- document conflict logging in docs and README
- test negation conflict logging

## Testing
- `pytest tests/test_conflict.py -q`
- `pytest -q`