### PR TITLE
Implement conflict detection

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -10,6 +10,7 @@ from .config import DEFAULT_BRAIN_PATH
 from .local_llm import LocalChatModel
 from .canonical import render_five_w_template
 from .memory_cues import MemoryCueRenderer
+from .conflict_flagging import ConflictFlagger, ConflictLogger
 
 __all__ = [
     "app",
@@ -28,6 +29,8 @@ __all__ = [
     "LocalChatModel",
     "render_five_w_template",
     "MemoryCueRenderer",
+    "ConflictFlagger",
+    "ConflictLogger",
 ]
 
 # Semantic version of the package

--- a/gist_memory/conflict_flagging.py
+++ b/gist_memory/conflict_flagging.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Detect and log potential memory conflicts."""
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .models import RawMemory
+
+
+_NEG_WORDS = {"not", "no", "never", "n't"}
+
+
+@dataclass
+class ConflictRecord:
+    prototype_id: str
+    memory_a: str
+    memory_b: str
+    reason: str
+    score: float
+
+
+class ConflictLogger:
+    """Append conflict records to ``conflicts.jsonl``."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(self, record: ConflictRecord) -> None:
+        with open(self.path, "a") as f:
+            f.write(json.dumps(record.__dict__) + "\n")
+
+
+class ConflictFlagger:
+    """Lightweight heuristic conflict detector."""
+
+    def __init__(self, logger: ConflictLogger, sim_threshold: float = 0.7) -> None:
+        self.logger = logger
+        self.sim_threshold = sim_threshold
+
+    # ------------------------------------------------------------------
+    def check_pair(
+        self,
+        prototype_id: str,
+        mem_a: RawMemory,
+        vec_a: np.ndarray,
+        mem_b: RawMemory,
+        vec_b: np.ndarray,
+    ) -> None:
+        score = float(np.dot(vec_a, vec_b))
+        if score < self.sim_threshold:
+            return
+        reason = self._text_conflict(mem_a.raw_text, mem_b.raw_text)
+        if reason:
+            rec = ConflictRecord(
+                prototype_id=prototype_id,
+                memory_a=mem_a.memory_id,
+                memory_b=mem_b.memory_id,
+                reason=reason,
+                score=score,
+            )
+            self.logger.log(rec)
+
+    # ------------------------------------------------------------------
+    def _text_conflict(self, a: str, b: str) -> str | None:
+        a_low = a.lower()
+        b_low = b.lower()
+
+        nums_a = re.findall(r"\b\d+\b", a_low)
+        nums_b = re.findall(r"\b\d+\b", b_low)
+        if nums_a and nums_b and nums_a != nums_b:
+            return "numeric_mismatch"
+
+        toks_a = a_low.split()
+        toks_b = b_low.split()
+        neg_a = [t for t in toks_a if t in _NEG_WORDS]
+        neg_b = [t for t in toks_b if t in _NEG_WORDS]
+        if bool(neg_a) != bool(neg_b):
+            clean_a = " ".join(t for t in toks_a if t not in _NEG_WORDS)
+            clean_b = " ".join(t for t in toks_b if t not in _NEG_WORDS)
+            if clean_a == clean_b:
+                return "negation_conflict"
+
+        return None
+
+
+__all__ = ["ConflictFlagger", "ConflictLogger", "ConflictRecord"]

--- a/tests/test_conflict_flagging.py
+++ b/tests/test_conflict_flagging.py
@@ -1,0 +1,45 @@
+import json
+import pytest
+from gist_memory.agent import Agent
+from gist_memory.json_npy_store import JsonNpyVectorStore
+from gist_memory.embedding_pipeline import MockEncoder
+from gist_memory.chunker import SentenceWindowChunker
+
+
+@pytest.fixture(autouse=True)
+def use_mock_encoder(monkeypatch):
+    enc = MockEncoder()
+    monkeypatch.setattr(
+        "gist_memory.embedding_pipeline._load_model", lambda *a, **k: enc
+    )
+    yield
+
+
+def test_numeric_conflict_logged(tmp_path):
+    store = JsonNpyVectorStore(
+        path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim
+    )
+    agent = Agent(store, chunker=SentenceWindowChunker(), similarity_threshold=0.7)
+    agent.add_memory("The event is on January 1")
+    agent.add_memory("The event is on January 2")
+    log_path = tmp_path / "conflicts.jsonl"
+    assert log_path.exists()
+    rows = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line.strip()
+    ]
+    assert rows
+    assert rows[0]["reason"] == "numeric_mismatch"
+
+
+def test_negation_conflict_logged(tmp_path):
+    store = JsonNpyVectorStore(
+        path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim
+    )
+    agent = Agent(store, chunker=SentenceWindowChunker(), similarity_threshold=0.7)
+    agent.add_memory("John is available")
+    agent.add_memory("John is not available")
+    log_path = tmp_path / "conflicts.jsonl"
+    rows = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line.strip()
+    ]
+    assert any(r["reason"] == "negation_conflict" for r in rows)


### PR DESCRIPTION
## Summary
- log potential belief conflicts to `conflicts.jsonl`
- detect numeric mismatches and negations
- expose new helper classes in the public API
- test conflict logging behaviour

## Testing
- `black gist_memory/conflict_flagging.py gist_memory/agent.py gist_memory/__init__.py tests/test_conflict_flagging.py`
- `flake8 gist_memory/conflict_flagging.py gist_memory/agent.py gist_memory/__init__.py tests/test_conflict_flagging.py` *(fails: command not found)*
- `pytest -q`