### PR TITLE
Improve model and store error handling

### DIFF
--- a/gist_memory/__main__.py
+++ b/gist_memory/__main__.py
@@ -2,6 +2,13 @@ import sys
 import logging
 from pathlib import Path
 
+try:  # optional pretty tracebacks
+    from rich.traceback import install as install_rich_traceback
+
+    install_rich_traceback()
+except Exception:  # pragma: no cover - rich may not be installed
+    pass
+
 from .logging_utils import configure_logging
 
 

--- a/gist_memory/embedding_pipeline.py
+++ b/gist_memory/embedding_pipeline.py
@@ -67,8 +67,8 @@ def _load_model(model_name: str, device: str) -> SentenceTransformer:
             _MODEL = SentenceTransformer(model_name, device=device)
         except Exception as exc:  # pragma: no cover - depends on local files
             raise RuntimeError(
-                "Embedding model not found. "
-                "Run `gist-memory download-model` to install it"
+                f"Error: Embedding Model '{model_name}' not found. "
+                f"Please run: gist-memory download-model --model-name {model_name} to install it."
             ) from exc
         _MODEL_NAME = model_name
         _DEVICE = device

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -33,9 +33,8 @@ class LocalChatModel:
             )
         except Exception as exc:  # pragma: no cover - depends on local files
             raise RuntimeError(
-                "Chat model not found. "
-                "Run `gist-memory download-chat-model --model-name "
-                f"{self.model_name}` to install it"
+                f"Error: Local Chat Model '{self.model_name}' not found. "
+                f"Please run: gist-memory download-chat-model --model-name {self.model_name} to install it."
             ) from exc
 
     def reply(self, prompt: str) -> str:

--- a/gist_memory/tui.py
+++ b/gist_memory/tui.py
@@ -73,11 +73,20 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
     if meta_exists:
         try:
             store = JsonNpyVectorStore(str(store_path))
-        except EmbeddingDimensionMismatchError:
-            dim = int(embed_text(["dim"]).shape[1])
-            store = JsonNpyVectorStore(str(store_path), embedding_dim=dim)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Brain directory '{store_path}' not found or is invalid"
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Error: Brain data is corrupted. {exc}. "
+                f"Try running gist-memory validate {store_path} for more details or restore from a backup."
+            ) from exc
     else:
-        dim = int(embed_text(["dim"]).shape[1])
+        try:
+            dim = int(embed_text(["dim"]).shape[1])
+        except RuntimeError as exc:
+            raise RuntimeError(str(exc)) from exc
         store = JsonNpyVectorStore(str(store_path), embedding_dim=dim)
     agent = Agent(store)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,3 +153,33 @@ def test_cli_logging(tmp_path):
     assert log_path.read_text() != ""
 
 
+def test_cli_corrupt_store(tmp_path):
+    runner = CliRunner()
+    runner.invoke(app, ["init", str(tmp_path)])
+    meta_path = tmp_path / "meta.yaml"
+    import yaml
+
+    meta = yaml.safe_load(meta_path.read_text())
+    meta["embedding_dim"] = 2
+    meta_path.write_text(yaml.safe_dump(meta))
+
+    result = runner.invoke(
+        app,
+        ["query", "--agent-name", str(tmp_path), "--query-text", "hi"],
+    )
+    assert result.exit_code != 0
+    assert "Brain data is corrupted" in result.stderr
+
+
+def test_cli_invalid_store(tmp_path):
+    runner = CliRunner()
+    # directory exists but store not initialised
+    path = tmp_path / "brain"
+    path.mkdir()
+    result = runner.invoke(
+        app, ["query", "--agent-name", str(path), "--query-text", "hi"]
+    )
+    assert result.exit_code != 0
+    assert "not found or is invalid" in result.stderr
+
+

--- a/tests/test_embedding_pipeline.py
+++ b/tests/test_embedding_pipeline.py
@@ -30,4 +30,6 @@ def test_load_model_failure(monkeypatch):
     monkeypatch.setattr(ep, "SentenceTransformer", raise_err)
     with pytest.raises(RuntimeError) as exc:
         ep._load_model("bad", "cpu")
-    assert "gist-memory download-model" in str(exc.value)
+    msg = str(exc.value)
+    assert "download-model" in msg
+    assert "bad" in msg


### PR DESCRIPTION
## Summary
- catch corrupted store errors and exit with helpful message
- surface missing model errors for embedding and chat models
- use rich.traceback for cleaner stack traces
- update CLI and TUI to rely on new error helpers
- add regression tests for new behaviours
- handle invalid store directory cases

## Testing
- `pytest -q`