### PR TITLE
Add TalkSessionManager

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -13,6 +13,7 @@ from .memory_cues import MemoryCueRenderer
 from .conflict_flagging import ConflictFlagger, ConflictLogger
 from .experiment_runner import ExperimentConfig, run_experiment
 from .conflict import ConflictLogger, negation_conflict
+from .talk_session import TalkSessionManager
 
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     "run_experiment",
     "ConflictLogger",
     "negation_conflict",
+    "TalkSessionManager",
 ]
 
 # Semantic version of the package

--- a/gist_memory/talk_session.py
+++ b/gist_memory/talk_session.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from .agent import Agent
+from .json_npy_store import JsonNpyVectorStore
+from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
+from .chunker import SentenceWindowChunker, Chunker
+
+
+def _load_agent(path: Path) -> Agent:
+    """Load a persisted agent from ``path``.
+
+    This mirrors the logic of the CLI helper for convenience.
+    """
+    try:
+        store = JsonNpyVectorStore(path=str(path))
+    except Exception as exc:
+        raise RuntimeError(f"Error loading agent at {path}: {exc}") from exc
+    except EmbeddingDimensionMismatchError:
+        dim = int(embed_text(["dim"]).shape[1])
+        store = JsonNpyVectorStore(path=str(path), embedding_dim=dim)
+    chunker_id = store.meta.get("chunker", "sentence_window")
+    chunker_cls: type[Chunker] = SentenceWindowChunker
+    if chunker_id == "sentence_window":
+        chunker_cls = SentenceWindowChunker
+    return Agent(store, chunker=chunker_cls(), similarity_threshold=float(store.meta.get("tau", 0.8)))
+
+
+@dataclass
+class TalkSession:
+    session_id: str
+    agents: Dict[str, Agent] = field(default_factory=dict)
+    log: List[Tuple[str, str]] = field(default_factory=list)
+
+
+class TalkSessionManager:
+    """Manage multi-agent talk sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, TalkSession] = {}
+
+    # ------------------------------------------------------------------
+    def create_session(self, agent_paths: Iterable[str | Path]) -> str:
+        """Create a session with agents loaded from ``agent_paths``.
+
+        Returns the new session ID.
+        """
+        sid = uuid.uuid4().hex
+        agents: Dict[str, Agent] = {}
+        for p in agent_paths:
+            path = Path(p)
+            agents[str(path)] = _load_agent(path)
+        self._sessions[sid] = TalkSession(session_id=sid, agents=agents)
+        return sid
+
+    def end_session(self, session_id: str) -> None:
+        """Terminate ``session_id`` if it exists."""
+        self._sessions.pop(session_id, None)
+
+    def get_session(self, session_id: str) -> TalkSession:
+        return self._sessions[session_id]
+
+    def post_message(self, session_id: str, sender: str, message: str) -> None:
+        """Append ``message`` from ``sender`` to the session log."""
+        session = self._sessions[session_id]
+        session.log.append((sender, message))

--- a/tests/test_talk_session.py
+++ b/tests/test_talk_session.py
@@ -1,0 +1,54 @@
+import pytest
+
+from gist_memory.talk_session import TalkSessionManager
+from gist_memory.agent import Agent
+from gist_memory.json_npy_store import JsonNpyVectorStore
+from gist_memory.embedding_pipeline import MockEncoder
+from gist_memory.chunker import SentenceWindowChunker
+
+
+@pytest.fixture(autouse=True)
+def use_mock_encoder(monkeypatch):
+    enc = MockEncoder()
+    monkeypatch.setattr("gist_memory.embedding_pipeline._load_model", lambda *a, **k: enc)
+    yield
+
+
+def _create_brain(path):
+    store = JsonNpyVectorStore(
+        path=str(path), embedding_model="mock", embedding_dim=MockEncoder.dim
+    )
+    agent = Agent(store, chunker=SentenceWindowChunker())
+    # avoid conflict flagging noise in tests
+    agent._conflicts = type("Dummy", (), {"check_pair": lambda *a, **k: None})()
+    agent.add_memory("alpha")
+    store.save()
+
+
+def test_create_and_end_session(tmp_path):
+    brain1 = tmp_path / "b1"
+    brain2 = tmp_path / "b2"
+    _create_brain(brain1)
+    _create_brain(brain2)
+
+    mgr = TalkSessionManager()
+    sid = mgr.create_session([brain1, brain2])
+
+    assert sid in mgr._sessions
+    session = mgr.get_session(sid)
+    assert len(session.agents) == 2
+
+    mgr.post_message(sid, "user", "hello")
+    assert session.log[-1] == ("user", "hello")
+
+    mgr.end_session(sid)
+    assert sid not in mgr._sessions
+
+
+def test_unique_ids(tmp_path):
+    brain = tmp_path / "b"
+    _create_brain(brain)
+    mgr = TalkSessionManager()
+    sid1 = mgr.create_session([brain])
+    sid2 = mgr.create_session([brain])
+    assert sid1 != sid2


### PR DESCRIPTION
## Summary
- implement TalkSessionManager for managing multi-agent talk sessions
- expose TalkSessionManager from package
- adjust Agent conflict logging to use separate loggers and avoid duplication
- add new tests for TalkSessionManager

## Testing
- `pytest -q`