### PR TITLE
Implement dynamic brain invite/kick

### DIFF
--- a/gist_memory/talk_session.py
+++ b/gist_memory/talk_session.py
@@ -68,3 +68,24 @@ class TalkSessionManager:
         """Append ``message`` from ``sender`` to the session log."""
         session = self._sessions[session_id]
         session.log.append((sender, message))
+
+    # ------------------------------------------------------------------
+    def invite_brain(self, session_id: str, brain_path_or_id: str | Path) -> None:
+        """Add a brain to an existing session.
+
+        Late-joining brains ingest the full message history so far.
+        """
+        session = self._sessions[session_id]
+        path = Path(brain_path_or_id)
+        key = str(path)
+        if key in session.agents:
+            return
+        agent = _load_agent(path)
+        for _sender, msg in session.log:
+            agent.add_memory(msg)
+        session.agents[key] = agent
+
+    def kick_brain(self, session_id: str, brain_id: str) -> None:
+        """Remove ``brain_id`` from the session if present."""
+        session = self._sessions[session_id]
+        session.agents.pop(brain_id, None)

--- a/tests/test_talk_session.py
+++ b/tests/test_talk_session.py
@@ -52,3 +52,25 @@ def test_unique_ids(tmp_path):
     sid1 = mgr.create_session([brain])
     sid2 = mgr.create_session([brain])
     assert sid1 != sid2
+
+
+def test_invite_and_kick(tmp_path):
+    brain1 = tmp_path / "b1"
+    brain2 = tmp_path / "b2"
+    brain3 = tmp_path / "b3"
+    _create_brain(brain1)
+    _create_brain(brain2)
+    _create_brain(brain3)
+
+    mgr = TalkSessionManager()
+    sid = mgr.create_session([brain1, brain2])
+    mgr.post_message(sid, "user", "hello")
+
+    mgr.invite_brain(sid, brain3)
+    session = mgr.get_session(sid)
+    assert len(session.agents) == 3
+    texts = [m.raw_text for m in session.agents[str(brain3)].store.memories]
+    assert "hello" in texts
+
+    mgr.kick_brain(sid, str(brain2))
+    assert str(brain2) not in session.agents


### PR DESCRIPTION
## Summary
- add `invite_brain` and `kick_brain` to `TalkSessionManager`
- allow late brain to ingest previous messages
- test new functionality

## Testing
- `pytest tests/test_talk_session.py::test_invite_and_kick -q`
- `pytest -q`