### PR TITLE
Implement IRC-style message routing

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -316,3 +316,8 @@ class Agent:
             "memories": mem_results,
             "status": "ok",
         }
+
+    # ------------------------------------------------------------------
+    def receive_channel_message(self, text: str) -> None:
+        """Handle a message broadcast from a talk session."""
+        self.add_memory(text)

--- a/tests/test_talk_session.py
+++ b/tests/test_talk_session.py
@@ -1,5 +1,7 @@
 import pytest
 
+import time
+
 from gist_memory.talk_session import TalkSessionManager
 from gist_memory.agent import Agent
 from gist_memory.json_npy_store import JsonNpyVectorStore
@@ -39,7 +41,10 @@ def test_create_and_end_session(tmp_path):
     assert len(session.agents) == 2
 
     mgr.post_message(sid, "user", "hello")
-    assert session.log[-1] == ("user", "hello")
+    sender, msg, ts = session.log[-1]
+    assert sender == "user"
+    assert msg == "hello"
+    assert ts <= time.time()
 
     mgr.end_session(sid)
     assert sid not in mgr._sessions
@@ -74,3 +79,32 @@ def test_invite_and_kick(tmp_path):
 
     mgr.kick_brain(sid, str(brain2))
     assert str(brain2) not in session.agents
+
+
+def test_message_routing(tmp_path):
+    brain1 = tmp_path / "b1"
+    brain2 = tmp_path / "b2"
+    _create_brain(brain1)
+    _create_brain(brain2)
+
+    mgr = TalkSessionManager()
+    sid = mgr.create_session([brain1, brain2])
+
+    received: list[tuple[str, str]] = []
+
+    mgr.register_listener(sid, "tui", lambda s, m: received.append((s, m)))
+
+    mgr.post_message(sid, "user", "hi")
+    session = mgr.get_session(sid)
+    for b in (brain1, brain2):
+        agent = session.agents[str(b)]
+        texts = [m.raw_text for m in agent.store.memories]
+        assert "hi" in texts
+    assert received == [("user", "hi")]
+
+    mgr.post_message(sid, str(brain1), "pong")
+    assert received == [("user", "hi"), (str(brain1), "pong")]
+    texts = [m.raw_text for m in session.agents[str(brain2)].store.memories]
+    assert "pong" in texts
+    texts1 = [m.raw_text for m in session.agents[str(brain1)].store.memories]
+    assert "pong" not in texts1


### PR DESCRIPTION
## Summary
- add listener support and timestamp logging to `TalkSessionManager`
- broadcast posted messages to all participants
- allow `Agent` to receive channel messages
- test message routing logic

## Testing
- `pytest -q`