### PR TITLE
Use spaCy for sentence segmentation

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -9,7 +9,8 @@ apt-get install -y --no-install-recommends python3 python3-pip git
 
 # Install Python dependencies if requirements.txt is present
 if [ -f requirements.txt ]; then
-    pip3 install --no-cache-dir -r requirements.txt
+pip3 install --no-cache-dir -r requirements.txt
+python3 -m spacy download en_core_web_sm
 else
     pip3 install --no-cache-dir textual
 fi

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ the default local embedding model (only needed the first time):
 
 ```bash
 pip install -r requirements.txt
+# download the spaCy model for sentence segmentation
+python -m spacy download en_core_web_sm
 # fetch the "all-MiniLM-L6-v2" model so the local embedder works offline
 gist-memory download-model --model-name all-MiniLM-L6-v2
 # fetch the default chat model for talk mode

--- a/gist_memory/segmentation.py
+++ b/gist_memory/segmentation.py
@@ -1,11 +1,12 @@
-import re
-from typing import List, Iterable
+from typing import Iterable, List
+
+from .spacy_utils import get_nlp
 
 
 def _sentences(text: str) -> List[str]:
-    """Split text into rough sentences."""
-    parts = re.split(r"(?<=[.!?])\s+|\n+", text.strip())
-    return [p.strip() for p in parts if p.strip()]
+    """Split text into sentences using spaCy."""
+    doc = get_nlp()(text.strip())
+    return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
 
 
 def _jaccard(a: Iterable[str], b: Iterable[str]) -> float:

--- a/gist_memory/spacy_utils.py
+++ b/gist_memory/spacy_utils.py
@@ -1,0 +1,17 @@
+import threading
+
+import spacy
+
+_MODEL_NAME = "en_core_web_sm"
+_lock = threading.Lock()
+_nlp = None
+
+
+def get_nlp():
+    """Load and return the shared spaCy model."""
+    global _nlp
+    if _nlp is None:
+        with _lock:
+            if _nlp is None:
+                _nlp = spacy.load(_MODEL_NAME)
+    return _nlp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pyyaml",
     "sentence-transformers",
     "transformers",
-    "nltk",
+    "spacy",
     "typer[all]",
     "portalocker",
     "textual>=0.46",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ sentence-transformers
 transformers
 textual  # required for the TUI
 rich>=13.6
-nltk
+spacy
 typer[all]
 portalocker

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from gist_memory.segmentation import agentic_split
+from gist_memory.segmentation import agentic_split, _sentences
 
 
 def test_agentic_split_long_text():
@@ -8,3 +8,9 @@ def test_agentic_split_long_text():
     chunks = agentic_split(text, max_tokens=40)
     assert len(chunks) > 5
     assert all(len(c.split()) <= 80 for c in chunks)
+
+
+def test_spacy_sentence_segmentation_abbreviation():
+    text = "Dr. Smith arrived at 5 p.m. He said hello. Goodbye."
+    sents = _sentences(text)
+    assert len(sents) == 3


### PR DESCRIPTION
## Summary
- integrate spaCy model loader
- replace NLTK and regex splitting with spaCy in SentenceWindowChunker
- use spaCy in agentic_split segmentation helper
- document model download in README and setup script
- add simple test covering abbreviation handling
- update dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spacy')*