### PR TITLE
Improve channel message processing

### DIFF
--- a/gist_memory/talk_session.py
+++ b/gist_memory/talk_session.py
@@ -88,7 +88,11 @@ class TalkSessionManager:
             if aid == sender:
                 continue
             if hasattr(agent, "receive_channel_message"):
-                agent.receive_channel_message(message)
+                try:
+                    agent.receive_channel_message(sender, message)
+                except TypeError:
+                    # fallback for old signature
+                    agent.receive_channel_message(message)  # type: ignore[arg-type]
             else:
                 agent.add_memory(message)
 


### PR DESCRIPTION
## Summary
- implement more nuanced logic in `Agent.receive_channel_message`
- add tests for ingest and query paths in `receive_channel_message`

## Testing
- `pytest tests/test_agent.py::test_receive_channel_ingest tests/test_agent.py::test_receive_channel_query -q`
- `pytest tests/test_cli.py::test_cli_talk -q`
- `pytest tests/test_talk_session.py::test_message_routing -q`