### PR TITLE
Integrate spaCy NER into importance filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 test = ["pytest"]
 chroma = ["chromadb"]
 tui = ["textual>=0.46", "rich>=13.6"]
+spacy = ["spacy"]
 
 [project.scripts]
 gist-memory = "gist_memory.__main__:main"

--- a/tests/test_importance_filter.py
+++ b/tests/test_importance_filter.py
@@ -1,3 +1,4 @@
+import pytest
 from gist_memory.importance_filter import dynamic_importance_filter
 
 
@@ -9,3 +10,21 @@ def test_dynamic_importance_filter():
     assert "WHEN: 2021" in out
     assert "uh-huh" not in out
     assert "random" not in out
+
+
+def test_dynamic_importance_filter_spacy():
+    spacy = pytest.importorskip("spacy")
+    from spacy.language import Language
+
+    nlp = spacy.blank("en")
+    ruler = nlp.add_pipe("entity_ruler")
+    ruler.add_patterns([
+        {"label": "PERSON", "pattern": "Alice"},
+        {"label": "DATE", "pattern": "2042"},
+    ])
+
+    text = "Random\nAlice met Bob\nThe year is 2042\n"
+    out = dynamic_importance_filter(text, nlp=nlp)
+    assert "Alice met Bob" in out
+    assert "2042" in out
+    assert "Random" not in out


### PR DESCRIPTION
## Summary
- extend requirements with `spacy`
- use optional spaCy NER in `dynamic_importance_filter`
- update docs for the new optional parameter
- add a new test covering spaCy usage

## Testing
- `pytest tests/test_importance_filter.py::test_dynamic_importance_filter -q`
- `pytest -q` *(53 passed, 1 skipped)*