### PR TITLE
Resolve ConflictLogger naming clash

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -12,7 +12,7 @@ from .canonical import render_five_w_template
 from .memory_cues import MemoryCueRenderer
 from .conflict_flagging import ConflictFlagger, ConflictLogger
 from .experiment_runner import ExperimentConfig, run_experiment
-from .conflict import ConflictLogger, negation_conflict
+from .conflict import SimpleConflictLogger, negation_conflict
 from .talk_session import TalkSessionManager
 
 
@@ -35,9 +35,9 @@ __all__ = [
     "MemoryCueRenderer",
     "ConflictFlagger",
     "ConflictLogger",
+    "SimpleConflictLogger",
     "ExperimentConfig",
     "run_experiment",
-    "ConflictLogger",
     "negation_conflict",
     "TalkSessionManager",
 ]

--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -22,7 +22,7 @@ from .memory_creation import (
 )
 from .canonical import render_five_w_template
 from .conflict_flagging import ConflictFlagger, ConflictLogger as FlagLogger
-from .conflict import ConflictLogger as SimpleConflictLogger, negation_conflict
+from .conflict import SimpleConflictLogger, negation_conflict
 
 
 class VectorIndexCorrupt(RuntimeError):

--- a/gist_memory/conflict.py
+++ b/gist_memory/conflict.py
@@ -24,7 +24,7 @@ def negation_conflict(text_a: str, text_b: str) -> bool:
     return subj_a == subj_b and obj_a == obj_b and neg_a != neg_b
 
 
-class ConflictLogger:
+class SimpleConflictLogger:
     """Append conflicts to ``conflicts.jsonl`` for HITL review."""
 
     def __init__(self, path: Path) -> None:
@@ -47,4 +47,4 @@ class ConflictLogger:
             )
 
 
-__all__ = ["negation_conflict", "ConflictLogger"]
+__all__ = ["negation_conflict", "SimpleConflictLogger"]


### PR DESCRIPTION
## Summary
- rename ConflictLogger from `conflict.py` to `SimpleConflictLogger`
- import the new name in `Agent`
- export the renamed class and drop duplicate export lines in `__init__`

## Testing
- `pytest -q` *(fails: dynamic_importance_filter_spacy, agentic_memory_creator, spacy_sentence_segmentation_abbreviation)*