### PR TITLE
Fix exports list and prepare lint/test tools

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -15,6 +15,9 @@ else
     pip3 install --no-cache-dir textual
 fi
 
+# Tools for linting and testing
+pip3 install --no-cache-dir flake8 pytest
+
 # Ensure CLI dependencies are available even when not listed in requirements
 pip3 install --no-cache-dir textual rich typer portalocker
 

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -17,32 +17,38 @@ from .talk_session import TalkSessionManager
 from .utils import load_agent
 
 
-__all__ = [
-    "app",
-    "BeliefPrototype",
-    "RawMemory",
-    "JsonNpyVectorStore",
-    "VectorStore",
-    "Agent",
-    "QueryResult",
-    "PrototypeHit",
-    "MemoryHit",
-    "embed_text",
-    "SentenceWindowChunker",
-    "FixedSizeChunker",
-    "DEFAULT_BRAIN_PATH",
-    "LocalChatModel",
-    "render_five_w_template",
-    "MemoryCueRenderer",
-    "ConflictFlagger",
-    "ConflictLogger",
-    "SimpleConflictLogger",
-    "ExperimentConfig",
-    "run_experiment",
-    "negation_conflict",
-    "TalkSessionManager",
-    "load_agent",
-]
+# Exported symbols.  ``dict.fromkeys`` ensures each value only appears once
+# while preserving the explicit ordering of the list below.
+__all__ = list(
+    dict.fromkeys(
+        [
+            "app",
+            "BeliefPrototype",
+            "RawMemory",
+            "JsonNpyVectorStore",
+            "VectorStore",
+            "Agent",
+            "QueryResult",
+            "PrototypeHit",
+            "MemoryHit",
+            "embed_text",
+            "SentenceWindowChunker",
+            "FixedSizeChunker",
+            "DEFAULT_BRAIN_PATH",
+            "LocalChatModel",
+            "render_five_w_template",
+            "MemoryCueRenderer",
+            "ConflictFlagger",
+            "ConflictLogger",
+            "SimpleConflictLogger",
+            "ExperimentConfig",
+            "run_experiment",
+            "negation_conflict",
+            "TalkSessionManager",
+            "load_agent",
+        ]
+    )
+)
 
 # Semantic version of the package
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- ensure `__all__` in `gist_memory` has unique entries using `dict.fromkeys`
- update setup script to install flake8 and pytest for tests

## Testing
- `black gist_memory/__init__.py`
- `flake8 gist_memory/__init__.py` *(fails: command not found)*
- `pytest tests/test_memory_creation.py::test_agentic_memory_creator -q` *(fails: AssertionError)*
