### PR TITLE
Implement prioritized pruning for history buffer

### DIFF
--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class ConversationTurn:
+    """Simple container for a conversation turn."""
+
+    text: str
+    trace_strength: float = 0.0
+    current_activation_level: float = 0.0
+
+
+@dataclass
+class ActiveMemoryManager:
+    """Manage a history buffer of conversation turns."""
+
+    config_max_history_buffer_turns: int = 100
+    config_prompt_num_forced_recent_turns: int = 0
+    config_pruning_weight_trace_strength: float = 1.0
+    config_pruning_weight_current_activation: float = 1.0
+    config_pruning_weight_recency: float = 0.1
+    history: List[ConversationTurn] = field(default_factory=list)
+
+    # --------------------------------------------------------------
+    def add_turn(self, turn: ConversationTurn) -> None:
+        """Add ``turn`` to the history, pruning if necessary."""
+        self.history.append(turn)
+        if len(self.history) > self.config_max_history_buffer_turns:
+            self._prune_history_buffer()
+
+    # --------------------------------------------------------------
+    def _prune_history_buffer(self) -> None:
+        """Prune the history buffer using weighted retention scores."""
+        max_turns = self.config_max_history_buffer_turns
+        forced_recent = self.config_prompt_num_forced_recent_turns
+
+        if len(self.history) <= max_turns:
+            return
+
+        # Slice off the forced recent turns which are never removed
+        if forced_recent > 0:
+            keep_slice = self.history[-forced_recent:]
+            candidates = self.history[:-forced_recent]
+        else:
+            keep_slice = []
+            candidates = list(self.history)
+
+        while len(candidates) + len(keep_slice) > max_turns and candidates:
+            n = len(candidates)
+            # Compute retention scores taking recency into account
+            scores = []
+            for idx, t in enumerate(candidates):
+                if n == 1:
+                    recency = 1.0
+                else:
+                    recency = idx / (n - 1)
+                score = (
+                    self.config_pruning_weight_trace_strength * t.trace_strength
+                    + self.config_pruning_weight_current_activation * t.current_activation_level
+                    + self.config_pruning_weight_recency * recency
+                )
+                scores.append(score)
+            min_index = scores.index(min(scores))
+            candidates.pop(min_index)
+
+        self.history = candidates + keep_slice
+
+
+__all__ = ["ConversationTurn", "ActiveMemoryManager"]

--- a/gist_memory/importance_filter.py
+++ b/gist_memory/importance_filter.py
@@ -76,7 +76,7 @@ def dynamic_importance_filter(text: str, nlp: Optional[object] = None) -> str:
         if re.search(r"\b\d{4}\b", part):
             salient.append(line)
             continue
-        if re.search(r"\b[A-Z][a-z]+\b", part):
+        if nlp is None and re.search(r"\b[A-Z][a-z]+\b", part):
             salient.append(line)
             continue
         if re.search(r"decision|decided", part, re.IGNORECASE):

--- a/gist_memory/segmentation.py
+++ b/gist_memory/segmentation.py
@@ -1,12 +1,26 @@
 from typing import Iterable, List
 
 from .spacy_utils import get_nlp
+import re
 
 
 def _sentences(text: str) -> List[str]:
     """Split text into sentences using spaCy."""
     doc = get_nlp()(text.strip())
-    return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+    sents = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+    if len(sents) <= 2:
+        parts = re.split(r"(?<=[.!?])\s+", text.strip())
+        merged: List[str] = []
+        i = 0
+        while i < len(parts):
+            part = parts[i]
+            if part in {"Dr.", "Mr.", "Mrs.", "Ms.", "Sr.", "Jr.", "St.", "Prof.", "p.m.", "a.m."} and i + 1 < len(parts):
+                part = part + " " + parts[i + 1]
+                i += 1
+            merged.append(part.strip())
+            i += 1
+        sents = [m for m in merged if m]
+    return sents
 
 
 def _jaccard(a: Iterable[str], b: Iterable[str]) -> float:

--- a/tests/test_active_memory_manager.py
+++ b/tests/test_active_memory_manager.py
@@ -1,0 +1,77 @@
+import pytest
+
+from gist_memory.active_memory_manager import ActiveMemoryManager, ConversationTurn
+
+
+def test_history_buffer_does_not_exceed_max_size():
+    mgr = ActiveMemoryManager(config_max_history_buffer_turns=3)
+    for i in range(5):
+        mgr.add_turn(ConversationTurn(text=str(i)))
+    assert len(mgr.history) == 3
+
+
+def test_pruning_retains_turns_with_high_trace_strength():
+    mgr = ActiveMemoryManager(
+        config_max_history_buffer_turns=3,
+        config_pruning_weight_trace_strength=1.0,
+        config_pruning_weight_current_activation=0.0,
+        config_pruning_weight_recency=0.0,
+    )
+    t1 = ConversationTurn("t1", trace_strength=0.1)
+    t2 = ConversationTurn("t2", trace_strength=0.9)
+    t3 = ConversationTurn("t3", trace_strength=0.2)
+    t4 = ConversationTurn("t4", trace_strength=0.1)
+    for t in (t1, t2, t3, t4):
+        mgr.add_turn(t)
+    assert t2 in mgr.history
+    assert len(mgr.history) == 3
+
+
+def test_pruning_retains_turns_with_high_current_activation():
+    mgr = ActiveMemoryManager(
+        config_max_history_buffer_turns=3,
+        config_pruning_weight_trace_strength=0.0,
+        config_pruning_weight_current_activation=1.0,
+        config_pruning_weight_recency=0.0,
+    )
+    t1 = ConversationTurn("t1", current_activation_level=0.1)
+    t2 = ConversationTurn("t2", current_activation_level=0.8)
+    t3 = ConversationTurn("t3", current_activation_level=0.2)
+    t4 = ConversationTurn("t4", current_activation_level=0.1)
+    for t in (t1, t2, t3, t4):
+        mgr.add_turn(t)
+    assert t2 in mgr.history
+    assert len(mgr.history) == 3
+
+
+def test_pruning_retains_most_recent_turns_if_configured():
+    mgr = ActiveMemoryManager(
+        config_max_history_buffer_turns=4,
+        config_prompt_num_forced_recent_turns=2,
+        config_pruning_weight_trace_strength=0.0,
+        config_pruning_weight_current_activation=0.0,
+        config_pruning_weight_recency=0.0,
+    )
+    turns = [ConversationTurn(str(i)) for i in range(5)]
+    for t in turns:
+        mgr.add_turn(t)
+    assert turns[-1] in mgr.history
+    assert turns[-2] in mgr.history
+    assert len(mgr.history) == 4
+
+
+def test_pruning_correctly_removes_lowest_priority_turn():
+    mgr = ActiveMemoryManager(
+        config_max_history_buffer_turns=3,
+        config_pruning_weight_trace_strength=1.0,
+        config_pruning_weight_current_activation=1.0,
+        config_pruning_weight_recency=0.0,
+    )
+    t1 = ConversationTurn("t1", trace_strength=0.2, current_activation_level=0.2)
+    t2 = ConversationTurn("t2", trace_strength=0.2, current_activation_level=0.8)
+    t3 = ConversationTurn("t3", trace_strength=0.9, current_activation_level=0.2)
+    t4 = ConversationTurn("t4", trace_strength=0.1, current_activation_level=0.1)
+    for t in (t1, t2, t3, t4):
+        mgr.add_turn(t)
+    assert t4 not in mgr.history
+    assert len(mgr.history) == 3


### PR DESCRIPTION
## Summary
- add ActiveMemoryManager with prioritized pruning of conversation turns
- implement pruning logic based on trace strength, activation, and recency
- add tests for ActiveMemoryManager behavior
- tweak importance filter to ignore capitalized lines when spaCy is used
- improve sentence segmentation fallback handling common abbreviations
- adjust LocalChatModel to support monkeypatched generate functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839f65265a483299ad546c9f8e81ec8