### PR TITLE
Expose ActiveMemoryManager parameters in experiments

### DIFF
--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 from gist_memory.experiment_runner import ExperimentConfig, run_experiment
+from gist_memory.active_memory_manager import ActiveMemoryManager
+from gist_memory.utils import load_agent
 from gist_memory.embedding_pipeline import MockEncoder
 import pytest
 
@@ -19,3 +21,31 @@ def test_run_experiment(tmp_path):
     metrics = run_experiment(cfg)
     assert metrics["memories_ingested"] >= 1
     assert metrics["prototype_count"] >= 1
+
+
+def test_experiment_can_override_default_active_memory_manager_params(tmp_path):
+    data = tmp_path / "data.txt"
+    data.write_text("hello world")
+    params = {"config_max_history_buffer_turns": 7}
+    cfg = ExperimentConfig(
+        dataset=data, work_dir=tmp_path, active_memory_params=params
+    )
+    run_experiment(cfg)
+    import yaml
+
+    meta = yaml.safe_load((tmp_path / "meta.yaml").read_text())
+    assert meta["config_max_history_buffer_turns"] == 7
+
+
+def test_agent_in_experiment_uses_overridden_active_memory_params(tmp_path):
+    data = tmp_path / "data.txt"
+    data.write_text("hello world")
+    params = {"config_initial_activation": 0.42}
+    cfg = ExperimentConfig(
+        dataset=data, work_dir=tmp_path, active_memory_params=params
+    )
+    run_experiment(cfg)
+    agent = load_agent(tmp_path)
+    meta_params = {k: v for k, v in agent.store.meta.items() if k.startswith("config_")}
+    mgr = ActiveMemoryManager(**meta_params)
+    assert mgr.config_initial_activation == pytest.approx(0.42)


### PR DESCRIPTION
## Summary
- allow ExperimentConfig to accept `active_memory_params`
- inject config values into JsonNpyVectorStore and ActiveMemoryManager during experiments
- add tests covering override of ActiveMemoryManager parameters and usage by agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a2f0f69c083298a6b796f0c160628