### PR TITLE
Add parameter view to TUI

### DIFF
--- a/gist_memory/tui/screens.py
+++ b/gist_memory/tui/screens.py
@@ -84,6 +84,7 @@ class HelpScreen(Screen):
             "/stats            - show store stats\n"
             "/install-models   - download models\n"
             "/talk             - chat session\n"
+            "/params           - agent parameters\n"
             "/log PATH        - write debug log\n"
             "/exit             - quit"
         )
@@ -295,6 +296,7 @@ class ConsoleScreen(StatusMixin):
             "/stats",
             "/install-models",
             "/talk",
+            "/params",
             "/log ",
             "/exit",
             "/quit",
@@ -347,6 +349,8 @@ class ConsoleScreen(StatusMixin):
             self.app.push_screen(BeliefScreen())
         elif cmd == "/talk":
             self.app.push_screen(ChatScreen())
+        elif cmd == "/params":
+            self.app.push_screen(ParamsScreen())
         elif cmd.startswith("/log "):
             path = Path(cmd[len("/log ") :]).expanduser()
             if not path.is_absolute():
@@ -369,6 +373,7 @@ class ConsoleScreen(StatusMixin):
             self.text_log.write_line("/stats       - show stats")
             self.text_log.write_line("/install-models - download models")
             self.text_log.write_line("/talk        - chat session")
+            self.text_log.write_line("/params      - agent parameters")
             self.text_log.write_line("/log PATH   - write debug log")
             self.text_log.write_line("/exit        - quit")
         elif cmd:
@@ -489,6 +494,32 @@ class StatsScreen(StatusMixin):
         yield Footer()
 
 
+class ParamsScreen(StatusMixin):
+    BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    def compose(self) -> ComposeResult:  # type: ignore[override]
+        table = DataTable(id="params")
+        table.add_columns("key", "value")
+        yield Header()
+        yield table
+        yield Static("", id="status")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#params", DataTable)
+        table.add_row("tau", str(agent.similarity_threshold))
+        chunk_cfg = getattr(agent.chunker, "config", lambda: {})()
+        chunk_id = chunk_cfg.pop("id", agent.chunker.__class__.__name__)
+        table.add_row("chunker", str(chunk_id))
+        for k, v in chunk_cfg.items():
+            table.add_row(f"chunker.{k}", str(v))
+
+        creator = agent.summary_creator
+        table.add_row("memory_creator", creator.__class__.__name__)
+        for k, v in vars(creator).items():
+            table.add_row(f"memory_creator.{k}", str(v))
+
+
 class ExitScreen(StatusMixin):
     BINDINGS = [
         ("y", "yes", "Yes"),
@@ -520,6 +551,7 @@ class WizardApp(App):
         ("q", "push_screen('exit')", "Quit"),
         ("f5", "push_screen('stats')", "Stats"),
         ("f6", "push_screen('group')", "Group"),
+        ("f7", "push_screen('params')", "Params"),
     ]
 
     SCREENS = {
@@ -527,6 +559,7 @@ class WizardApp(App):
         "console": ConsoleScreen,
         "beliefs": BeliefScreen,
         "stats": StatsScreen,
+        "params": ParamsScreen,
         "group": GroupSessionScreen,
         "talk": ChatScreen,
         "exit": ExitScreen,
@@ -553,6 +586,7 @@ __all__ = [
     "ChatScreen",
     "ConsoleScreen",
     "GroupSessionScreen",
+    "ParamsScreen",
     "StatsScreen",
     "ExitScreen",
 ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -97,6 +97,10 @@ def test_wizard_create_exit_no(monkeypatch, tmp_path):
 
     _patch_run(monkeypatch, autopilot)
     run_tui(str(tmp_path))
+
+    store = JsonNpyVectorStore(str(tmp_path))
+    assert len(store.memories) == 1
+    assert len(store.prototypes) == 1
     store = JsonNpyVectorStore(str(tmp_path))
     assert len(store.memories) == 1
     assert len(store.prototypes) == 1
@@ -259,3 +263,20 @@ def test_group_session_invite(monkeypatch, tmp_path):
     store = JsonNpyVectorStore(str(brain2))
     texts = [m.raw_text for m in store.memories]
     assert "hi" in texts
+
+
+def test_params_screen(monkeypatch, tmp_path):
+    _patch_mock_encoder(monkeypatch)
+
+    async def autopilot(pilot):
+        await pilot.press("c")
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.press("f7")
+        await pilot.press("q")
+        await pilot.pause(0.1)
+        await pilot.press("n")
+        await pilot.exit(None)
+
+    _patch_run(monkeypatch, autopilot)
+    run_tui(str(tmp_path))


### PR DESCRIPTION
## Summary
- add `ParamsScreen` displaying agent configuration
- expose `/params` command and F7 hotkey
- document new command in help
- test opening the new screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a303a498083299d5dc9552c039a69