### PR TITLE
Add history tuning experiment

### DIFF
--- a/examples/history_dialogues.yaml
+++ b/examples/history_dialogues.yaml
@@ -1,0 +1,13 @@
+- turns:
+    - user: "Remember that module B depends on A."
+    - assistant: "Okay."
+    - user: "Also C depends on B."
+    - assistant: "Understood."
+  query: "Which module does C depend on?"
+  required_turn_index: 2
+- turns:
+    - user: "Let's define variable 'secret' as 123."
+    - assistant: "Got it."
+    - user: "I'll ask you for the secret later."
+  query: "What is the secret value?"
+  required_turn_index: 0

--- a/examples/history_tuning_experiment.py
+++ b/examples/history_tuning_experiment.py
@@ -1,0 +1,28 @@
+"""Example script to tune ActiveMemoryManager history parameters."""
+from pathlib import Path
+import yaml
+
+from gist_memory.history_experiment import HistoryExperimentConfig, run_history_experiment
+
+
+def main() -> None:
+    dataset = Path(__file__).parent / "history_dialogues.yaml"
+    param_grid = [
+        {
+            "config_prompt_num_forced_recent_turns": 1,
+            "config_prompt_max_activated_older_turns": 1,
+            "config_relevance_boost_factor": 1.0,
+        },
+        {
+            "config_prompt_num_forced_recent_turns": 2,
+            "config_prompt_max_activated_older_turns": 2,
+            "config_relevance_boost_factor": 1.5,
+        },
+    ]
+    cfg = HistoryExperimentConfig(dataset=dataset, param_grid=param_grid)
+    results = run_history_experiment(cfg)
+    print(yaml.safe_dump(results, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -12,6 +12,7 @@ from .canonical import render_five_w_template
 from .memory_cues import MemoryCueRenderer
 from .conflict_flagging import ConflictFlagger, ConflictLogger
 from .experiment_runner import ExperimentConfig, run_experiment
+from .history_experiment import HistoryExperimentConfig, run_history_experiment
 from .conflict import SimpleConflictLogger, negation_conflict
 from .talk_session import TalkSessionManager
 from .utils import load_agent
@@ -44,6 +45,8 @@ __all__ = list(
             "SimpleConflictLogger",
             "ExperimentConfig",
             "run_experiment",
+            "HistoryExperimentConfig",
+            "run_history_experiment",
             "negation_conflict",
             "TalkSessionManager",
             "load_agent",

--- a/gist_memory/history_experiment.py
+++ b/gist_memory/history_experiment.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+
+import yaml
+
+from .active_memory_manager import ActiveMemoryManager, ConversationTurn
+from .embedding_pipeline import MockEncoder
+
+
+@dataclass
+class HistoryExperimentConfig:
+    """Configuration for :func:`run_history_experiment`."""
+
+    dataset: Path
+    param_grid: List[Dict[str, Any]]
+
+
+# --------------------------------------------------------------
+def _load_dataset(path: Path) -> List[Dict[str, Any]]:
+    data = yaml.safe_load(path.read_text())
+    return list(data)
+
+
+# --------------------------------------------------------------
+def _evaluate_dialogue(sample: Dict[str, Any], params: Dict[str, Any], encoder: MockEncoder) -> bool:
+    mgr = ActiveMemoryManager(**params)
+    for turn in sample["turns"]:
+        if isinstance(turn, dict):
+            text = turn.get("text") or next(iter(turn.values()))
+        else:
+            text = str(turn)
+        emb = encoder.encode(text)
+        mgr.add_turn(ConversationTurn(text=text, turn_embedding=emb.tolist()))
+    query = sample["query"]
+    query_emb = encoder.encode(query)
+    candidates = mgr.select_history_candidates_for_prompt(query_emb)
+    idx = int(sample["required_turn_index"])
+    req_turn = sample["turns"][idx]
+    if isinstance(req_turn, dict):
+        required_text = req_turn.get("text") or next(iter(req_turn.values()))
+    else:
+        required_text = str(req_turn)
+    return any(t.text == required_text for t in candidates)
+
+
+# --------------------------------------------------------------
+def run_history_experiment(config: HistoryExperimentConfig) -> List[Dict[str, Any]]:
+    """Run history parameter tuning experiment on ``config.dataset``."""
+
+    dataset = _load_dataset(config.dataset)
+    encoder = MockEncoder()
+    results = []
+    for params in config.param_grid:
+        successes = 0
+        for sample in dataset:
+            if _evaluate_dialogue(sample, params, encoder):
+                successes += 1
+        hit_rate = successes / len(dataset) if dataset else 0.0
+        results.append({"params": params, "hit_rate": hit_rate})
+    return results
+
+
+__all__ = ["HistoryExperimentConfig", "run_history_experiment"]

--- a/tests/data/history_dialogues.yaml
+++ b/tests/data/history_dialogues.yaml
@@ -1,0 +1,13 @@
+- turns:
+    - user: "Remember that module B depends on A."
+    - assistant: "Okay."
+    - user: "Also C depends on B."
+    - assistant: "Understood."
+  query: "Which module does C depend on?"
+  required_turn_index: 2
+- turns:
+    - user: "Let's define variable 'secret' as 123."
+    - assistant: "Got it."
+    - user: "I'll ask you for the secret later."
+  query: "What is the secret value?"
+  required_turn_index: 0

--- a/tests/test_history_experiment.py
+++ b/tests/test_history_experiment.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from gist_memory.history_experiment import HistoryExperimentConfig, run_history_experiment
+from gist_memory.embedding_pipeline import MockEncoder
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def use_mock_encoder(monkeypatch):
+    enc = MockEncoder()
+    monkeypatch.setattr("gist_memory.history_experiment.MockEncoder", lambda: enc)
+    yield
+
+
+def test_history_experiment_runs(tmp_path):
+    data = Path(__file__).parent / "data" / "history_dialogues.yaml"
+    params = [
+        {
+            "config_prompt_num_forced_recent_turns": 1,
+            "config_prompt_max_activated_older_turns": 1,
+            "config_relevance_boost_factor": 1.0,
+        },
+        {
+            "config_prompt_num_forced_recent_turns": 2,
+            "config_prompt_max_activated_older_turns": 2,
+            "config_relevance_boost_factor": 1.5,
+        },
+    ]
+    cfg = HistoryExperimentConfig(dataset=data, param_grid=params)
+    results = run_history_experiment(cfg)
+    assert len(results) == 2
+    for res in results:
+        assert 0.0 <= res["hit_rate"] <= 1.0


### PR DESCRIPTION
## Summary
- add example dialogue dataset
- add HistoryExperimentConfig and run_history_experiment
- expose new experiment in package init
- provide example script for tuning history parameters
- test experiment script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a38d8dbf08329a1a8dabe3431a2df