### PR TITLE
Add unified stats and prototype view helpers

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -139,6 +139,39 @@ class Agent:
         self._conflicts = ConflictFlagger(FlagLogger(c))
 
     # ------------------------------------------------------------------
+    def get_statistics(self) -> Dict[str, object]:
+        """Return summary statistics about the current store."""
+
+        from .utils import get_disk_usage
+
+        path = Path(self.store.path)
+        return {
+            "prototypes": len(self.store.prototypes),
+            "memories": len(self.store.memories),
+            "tau": self.similarity_threshold,
+            "updated": self.store.meta.get("updated_at"),
+            "disk_usage": get_disk_usage(path),
+        }
+
+    # ------------------------------------------------------------------
+    def get_prototypes_view(self, sort_by: str | None = None) -> List[Dict[str, object]]:
+        """Return list of prototypes for display purposes."""
+
+        protos = list(self.store.prototypes)
+        if sort_by == "strength":
+            protos.sort(key=lambda p: p.strength, reverse=True)
+
+        return [
+            {
+                "id": p.prototype_id,
+                "strength": p.strength,
+                "confidence": p.confidence,
+                "summary": p.summary_text,
+            }
+            for p in protos
+        ]
+
+    # ------------------------------------------------------------------
     def _log_conflict(self, proto_id: str, mem_a: RawMemory, mem_b: RawMemory) -> None:
         self._conflict_logger.add(proto_id, mem_a, mem_b)
 

--- a/gist_memory/tui/__init__.py
+++ b/gist_memory/tui/__init__.py
@@ -1,4 +1,3 @@
 from .app import run_tui
-from .helpers import _disk_usage
 
-__all__ = ["run_tui", "_disk_usage"]
+__all__ = ["run_tui"]

--- a/gist_memory/tui/app.py
+++ b/gist_memory/tui/app.py
@@ -8,7 +8,7 @@ from ..config import DEFAULT_BRAIN_PATH
 from ..embedding_pipeline import embed_text
 from ..talk_session import TalkSessionManager
 
-from .helpers import _disk_usage, _install_models
+from .helpers import _install_models
 from .screens import WizardApp, set_context
 
 
@@ -45,4 +45,4 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
     WizardApp().run()
 
 
-__all__ = ["run_tui", "_disk_usage", "_install_models"]
+__all__ = ["run_tui", "_install_models"]

--- a/gist_memory/tui/helpers.py
+++ b/gist_memory/tui/helpers.py
@@ -1,20 +1,6 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
-
-
-def _disk_usage(path: Path) -> int:
-    """Return total size of files under ``path`` in bytes."""
-    size = 0
-    for root, _, files in os.walk(path):
-        for name in files:
-            fp = Path(root) / name
-            try:
-                size += fp.stat().st_size
-            except OSError:
-                pass
-    return size
 
 
 def _install_models(
@@ -56,6 +42,10 @@ def _path_suggestions(prefix: str, limit: int = 5) -> list[str]:
 
 def _brain_path_suggestions(base: Path, prefix: str, limit: int = 5) -> list[str]:
     """Return sub directories under ``base`` that look like brains."""
+    path = Path(prefix)
+    if path.is_absolute():
+        base = path.parent
+        prefix = path.name
     suggestions: list[str] = []
     for p in base.glob(prefix + "*"):
         if (p / "meta.yaml").exists():
@@ -66,7 +56,6 @@ def _brain_path_suggestions(base: Path, prefix: str, limit: int = 5) -> list[str
 
 
 __all__ = [
-    "_disk_usage",
     "_install_models",
     "_path_suggestions",
     "_brain_path_suggestions",

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,7 +1,8 @@
 import builtins
 import pytest
 from textual.app import App
-from gist_memory.tui import _disk_usage, run_tui
+from gist_memory.tui import run_tui
+from gist_memory.utils import get_disk_usage
 from gist_memory.json_npy_store import JsonNpyVectorStore
 from gist_memory.embedding_pipeline import MockEncoder
 from gist_memory.agent import Agent
@@ -14,7 +15,7 @@ def test_disk_usage(tmp_path):
     f2 = tmp_path / "b.txt"
     f2.write_text("beta")
     expected = f1.stat().st_size + f2.stat().st_size
-    assert _disk_usage(tmp_path) == expected
+    assert get_disk_usage(tmp_path) == expected
 
 
 def test_run_tui_import_error(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- centralize disk usage helper in `utils.get_disk_usage`
- expose `Agent.get_statistics` and `Agent.get_prototypes_view`
- refactor CLI commands to use new helpers
- update TUI screens to rely on agent getters
- fix brain path suggestions for absolute paths
- adjust tests for new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a40da015c8329b1f429d16ed9903a