### PR TITLE
centralize model download utils

### DIFF
--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -445,11 +445,11 @@ def download_model(
     )
 ) -> None:
     """Pre-download a local embedding model."""
-    from sentence_transformers import SentenceTransformer
     from tqdm import tqdm
+    from .model_utils import download_embedding_model
 
     bar = tqdm(total=1, desc="Downloading model", disable=False)
-    SentenceTransformer(model_name)
+    download_embedding_model(model_name)
     bar.update(1)
     bar.close()
     typer.echo(f"Downloaded {model_name}")
@@ -460,12 +460,11 @@ def download_chat_model(
     model_name: str = typer.Option("distilgpt2", help="Local causal LM name")
 ) -> None:
     """Pre-download a local chat model for ``talk`` mode."""
-    from transformers import AutoModelForCausalLM, AutoTokenizer
     from tqdm import tqdm
+    from .model_utils import download_chat_model as _download_chat_model
 
     bar = tqdm(total=1, desc="Downloading chat model", disable=False)
-    AutoTokenizer.from_pretrained(model_name)
-    AutoModelForCausalLM.from_pretrained(model_name)
+    _download_chat_model(model_name)
     bar.update(1)
     bar.close()
     typer.echo(f"Downloaded {model_name}")

--- a/gist_memory/model_utils.py
+++ b/gist_memory/model_utils.py
@@ -1,0 +1,24 @@
+"""Utility functions for model downloads."""
+
+from __future__ import annotations
+
+
+def download_embedding_model(model_name: str) -> None:
+    """Download a SentenceTransformer embedding model."""
+    from sentence_transformers import SentenceTransformer
+
+    SentenceTransformer(model_name)
+
+
+def download_chat_model(model_name: str) -> None:
+    """Download a local chat model (tokenizer and weights)."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    AutoTokenizer.from_pretrained(model_name)
+    AutoModelForCausalLM.from_pretrained(model_name)
+
+
+__all__ = [
+    "download_embedding_model",
+    "download_chat_model",
+]

--- a/gist_memory/tui/helpers.py
+++ b/gist_memory/tui/helpers.py
@@ -21,13 +21,11 @@ def _install_models(
     embed_model: str = "all-MiniLM-L6-v2", chat_model: str = "distilgpt2"
 ) -> str:
     """Download the default embedding and chat models."""
-    try:
-        from sentence_transformers import SentenceTransformer
-        from transformers import AutoModelForCausalLM, AutoTokenizer
+    from ..model_utils import download_embedding_model, download_chat_model
 
-        SentenceTransformer(embed_model)
-        AutoTokenizer.from_pretrained(chat_model)
-        AutoModelForCausalLM.from_pretrained(chat_model)
+    try:
+        download_embedding_model(embed_model)
+        download_chat_model(chat_model)
     except Exception as exc:  # pragma: no cover - network / file errors
         return f"error installing models: {exc}"
 


### PR DESCRIPTION
## Summary
- centralize embedding and chat model download logic in `model_utils`
- use these utilities in CLI and TUI

## Testing
- `pytest tests/test_cli.py::test_cli_download_chat_model tests/test_tui.py::test_install_models_command -q`

------
https://chatgpt.com/codex/tasks/task_e_683a409ad4188329a46b9348ca4b6488