### PR TITLE
Fix STM token budgeting using active model limits

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -385,9 +385,15 @@ class Agent:
             vec = vec.reshape(-1)
 
         history_candidates = manager.select_history_candidates_for_prompt(vec)
+        if hasattr(llm, "_context_length"):
+            max_hist = llm._context_length() - llm.max_new_tokens
+        else:  # fallback for test doubles
+            cfg = getattr(getattr(llm, "model", None), "config", None)
+            max_len = getattr(cfg, "n_positions", 1024)
+            max_hist = max_len - llm.max_new_tokens
         history_final = manager.finalize_history_for_prompt(
             history_candidates,
-            llm.model.config.n_positions - llm.max_new_tokens,
+            max_hist,
             llm.tokenizer,
         )
 


### PR DESCRIPTION
## Summary
- derive context length from local model or tokenizer
- use context length to limit short term memory in Agent
- test tokenizer fallback for context length

## Testing
- `pytest tests/test_token_limits.py::test_context_length_uses_tokenizer_when_config_missing -q`
- `pytest tests/test_agent.py::test_process_conversational_turn_updates_manager tests/test_cli.py::test_cli_talk -q`


------
https://chatgpt.com/codex/tasks/task_e_683a617d5ae083298d485521bdcd827a