### PR TITLE
Pin numpy for macOS stability

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -10,6 +10,8 @@ apt-get install -y --no-install-recommends python3 python3-pip git
 # Install Python dependencies if requirements.txt is present
 if [ -f requirements.txt ]; then
 pip3 install --no-cache-dir -r requirements.txt
+# Work around buggy macOS wheels
+pip3 install --no-cache-dir --force-reinstall "numpy<1.26"
 python3 -m spacy download en_core_web_sm
 else
     pip3 install --no-cache-dir textual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "openai",
     "tiktoken",
-    "numpy",
+    "numpy<1.26",
     "faiss-cpu",
     "click",
     "tqdm",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 openai
 tiktoken
-numpy
+numpy<1.26  # avoid Accelerate/BLAS segfaults on macOS
 faiss-cpu
 click
 tqdm


### PR DESCRIPTION
## Summary
- pin `numpy` to a version known to work on macOS
- force reinstall of the pinned version during setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b03bbfa0083299fc6bd5a3463f4f1