### PR TITLE
Implement token counting utility

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -33,6 +33,8 @@ __all__ = [
     "negation_conflict",
     "TalkSessionManager",
     "load_agent",
+    "tokenize_text",
+    "token_count",
 ]
 
 _lazy_map = {
@@ -63,6 +65,8 @@ _lazy_map = {
     "negation_conflict": "gist_memory.conflict",
     "TalkSessionManager": "gist_memory.talk_session",
     "load_agent": "gist_memory.utils",
+    "tokenize_text": "gist_memory.token_utils",
+    "token_count": "gist_memory.token_utils",
 }
 
 

--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .token_utils import token_count
+
 import numpy as np
 
 
@@ -182,26 +184,7 @@ class ActiveMemoryManager:
                 agent = getattr(turn, "agent_response", "")
                 text = f"{user}\n{agent}".strip()
 
-            if hasattr(llm_tokenizer, "tokenize"):
-                try:
-                    tokens = llm_tokenizer.tokenize(text)
-                except Exception:
-                    tokens = llm_tokenizer(text, return_tensors=None).get(
-                        "input_ids", []
-                    )
-            else:
-                tokens = llm_tokenizer(text, return_tensors=None).get(
-                    "input_ids", []
-                )
-
-            if isinstance(tokens, (list, tuple)):
-                if tokens and isinstance(tokens[0], (list, tuple)):
-                    token_list = list(tokens[0])
-                else:
-                    token_list = list(tokens)
-            else:
-                token_list = [tokens]
-            n_tokens = len(token_list)
+            n_tokens = token_count(llm_tokenizer, text)
 
             if current_tokens + n_tokens <= max_tokens_for_history:
                 kept_ids.add(id(turn))

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .agent import Agent
 
 from .importance_filter import dynamic_importance_filter
+from .token_utils import token_count
 
 try:  # heavy dependency only when needed
     from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -102,7 +103,7 @@ class LocalChatModel:
             except Exception:
                 ids = [ids_raw]  # type: ignore[list-item]
 
-        if len(ids) > max_input_len:
+        if token_count(self.tokenizer, prompt) > max_input_len:
             excess = len(ids) - max_input_len
             old_ids, keep_ids = ids[:excess], ids[excess:]
             old_text = self.tokenizer.decode(old_ids, skip_special_tokens=True)
@@ -170,7 +171,7 @@ class LocalChatModel:
 
         max_len = self._context_length()
         tokens = self.tokenizer(prompt, return_tensors="pt")["input_ids"][0]
-        if len(tokens) <= max_len:
+        if token_count(self.tokenizer, prompt) <= max_len:
             return prompt
 
         old_tokens = tokens[:-recent_tokens]

--- a/gist_memory/token_utils.py
+++ b/gist_memory/token_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Helper utilities for tokenizer interaction."""
+
+from typing import Any, List
+
+
+def tokenize_text(tokenizer: Any, text: str) -> List[int]:
+    """Return a flat list of token ids for ``text`` using ``tokenizer``."""
+    if hasattr(tokenizer, "tokenize"):
+        try:
+            tokens = tokenizer.tokenize(text)
+        except Exception:
+            tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+    else:
+        tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+
+    if isinstance(tokens, (list, tuple)):
+        if tokens and isinstance(tokens[0], (list, tuple)):
+            token_list = list(tokens[0])
+        else:
+            token_list = list(tokens)
+    else:
+        token_list = [tokens]
+    return token_list
+
+
+def token_count(tokenizer: Any, text: str) -> int:
+    """Return the number of tokens in ``text`` using ``tokenizer``."""
+    return len(tokenize_text(tokenizer, text))
+
+
+__all__ = ["tokenize_text", "token_count"]


### PR DESCRIPTION
## Summary
- add `tokenize_text`/`token_count` helpers for unified counting
- use `token_count` in `ActiveMemoryManager.finalize_history_for_prompt`
- expose new helpers via `gist_memory.__init__`
- ensure `LocalChatModel` uses shared counting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b2053abdc8329a87ae3020e2e4f43