### PR TITLE
Implement token budget configuration for agent prompts

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -35,6 +35,7 @@ __all__ = [
     "load_agent",
     "tokenize_text",
     "token_count",
+    "PromptBudget",
 ]
 
 _lazy_map = {
@@ -67,6 +68,7 @@ _lazy_map = {
     "load_agent": "gist_memory.utils",
     "tokenize_text": "gist_memory.token_utils",
     "token_count": "gist_memory.token_utils",
+    "PromptBudget": "gist_memory.prompt_budget",
 }
 
 

--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .prompt_budget import PromptBudget
+
 from .token_utils import token_count
 
 import numpy as np
@@ -34,6 +36,7 @@ class ActiveMemoryManager:
     config_min_activation_floor: float = 0.0
     config_relevance_boost_factor: float = 1.0
     history: List[ConversationTurn] = field(default_factory=list)
+    prompt_budget: Optional[PromptBudget] = None
 
     # --------------------------------------------------------------
     def add_turn(self, turn: ConversationTurn) -> None:

--- a/gist_memory/prompt_budget.py
+++ b/gist_memory/prompt_budget.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union, Dict
+
+
+Number = Union[int, float]
+
+
+@dataclass
+class PromptBudget:
+    """Token budget configuration for prompt assembly."""
+
+    query: Optional[Number] = None
+    recent_history: Optional[Number] = None
+    older_history: Optional[Number] = None
+    ltm_snippets: Optional[Number] = None
+
+    def resolve(self, total_tokens: int) -> Dict[str, int]:
+        """Return absolute token counts for ``total_tokens``."""
+
+        def _resolve(value: Optional[Number]) -> int:
+            if value is None:
+                return 0
+            if isinstance(value, float):
+                return int(total_tokens * value)
+            return int(value)
+
+        return {
+            "query": _resolve(self.query),
+            "recent_history": _resolve(self.recent_history),
+            "older_history": _resolve(self.older_history),
+            "ltm_snippets": _resolve(self.ltm_snippets),
+        }
+
+
+__all__ = ["PromptBudget"]

--- a/gist_memory/token_utils.py
+++ b/gist_memory/token_utils.py
@@ -30,4 +30,20 @@ def token_count(tokenizer: Any, text: str) -> int:
     return len(tokenize_text(tokenizer, text))
 
 
-__all__ = ["tokenize_text", "token_count"]
+def truncate_text(tokenizer: Any, text: str, max_tokens: int) -> str:
+    """Return ``text`` truncated to ``max_tokens`` using ``tokenizer``."""
+    tokens = tokenize_text(tokenizer, text)
+    if len(tokens) <= max_tokens:
+        return text
+    trimmed = tokens[:max_tokens]
+    if hasattr(tokenizer, "decode"):
+        try:
+            return tokenizer.decode(trimmed, skip_special_tokens=True)
+        except Exception:
+            pass
+    if all(isinstance(t, str) for t in trimmed):
+        return " ".join(trimmed)
+    return " ".join(text.split()[:max_tokens])
+
+
+__all__ = ["tokenize_text", "token_count", "truncate_text"]


### PR DESCRIPTION
## Summary
- add `PromptBudget` dataclass for STM/LTM token ratios or counts
- export new budget class in package init
- extend `ActiveMemoryManager` and `Agent` to hold optional budgets
- enforce token budgets when assembling prompts
- expose helper `truncate_text`
- test that prompt budgets truncate user query text

## Testing
- `pytest tests/test_agent.py::test_prompt_budget_truncates_prompt -q`


------
https://chatgpt.com/codex/tasks/task_e_683b27bac7a483299dbff165861d239e