### PR TITLE
Improve logging for prompt assembly

### DIFF
--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -8,6 +8,7 @@ from .prompt_budget import PromptBudget
 from .token_utils import token_count
 
 import numpy as np
+import logging
 
 
 @dataclass
@@ -155,7 +156,14 @@ class ActiveMemoryManager:
         # preserve original order of selected older turns
         selected_older.sort(key=lambda t: self.history.index(t))
 
-        return selected_older + list(recent_slice)
+        selected = selected_older + list(recent_slice)
+        logging.debug(
+            "[prompt] select_history candidates=%d recent=%d older=%d",
+            len(selected),
+            len(recent_slice),
+            len(selected_older),
+        )
+        return selected
 
     # --------------------------------------------------------------
     def finalize_history_for_prompt(


### PR DESCRIPTION
## Summary
- add debug logging in `ActiveMemoryManager.select_history_candidates_for_prompt`
- report token counts during prompt creation in `Agent.process_conversational_turn`
- log truncation behaviour inside `LocalChatModel.prepare_prompt`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after tests finished)*

------
https://chatgpt.com/codex/tasks/task_e_683b2e5856c08329b5d9e61d96e13cdd