### PR TITLE
Add response experiment framework

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -499,6 +499,7 @@ class Agent:
         prompt = llm.prepare_prompt(self, prompt)
         after_llm_tokens = token_count(llm.tokenizer, prompt)
         logging.debug("[prompt] after prepare tokens=%d", after_llm_tokens)
+        prompt_tokens = after_llm_tokens
         reply = llm.reply(prompt)
 
         manager.add_turn(
@@ -508,7 +509,7 @@ class Agent:
             )
         )
 
-        return reply, {"query_result": query_res}
+        return reply, {"query_result": query_res, "prompt_tokens": prompt_tokens}
 
     # ------------------------------------------------------------------
     def receive_channel_message(

--- a/gist_memory/response_experiment.py
+++ b/gist_memory/response_experiment.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Run end-to-end experiments evaluating prompt strategies."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+
+import tempfile
+import yaml
+
+from .agent import Agent
+from .active_memory_manager import ActiveMemoryManager, ConversationTurn
+from .json_npy_store import JsonNpyVectorStore
+from .embedding_pipeline import MockEncoder
+from .chunker import SentenceWindowChunker
+from .token_utils import token_count
+
+
+@dataclass
+class ResponseExperimentConfig:
+    """Configuration for :func:`run_response_experiment`."""
+
+    dataset: Path
+    param_grid: List[Dict[str, Any]]
+
+
+def _load_dataset(path: Path) -> List[Dict[str, Any]]:
+    data = yaml.safe_load(path.read_text())
+    return list(data)
+
+
+def _simple_f1(reference: str, prediction: str) -> float:
+    ref = reference.split()
+    pred = prediction.split()
+    if not ref or not pred:
+        return 0.0
+    common = set(ref) & set(pred)
+    if not common:
+        return 0.0
+    precision = len(common) / len(pred)
+    recall = len(common) / len(ref)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _evaluate_sample(sample: Dict[str, Any], params: Dict[str, Any], enc: MockEncoder) -> Dict[str, Any]:
+    mgr = ActiveMemoryManager(**params)
+
+    work_dir = tempfile.mkdtemp()
+    store = JsonNpyVectorStore(path=work_dir, embedding_model="experiment", embedding_dim=enc.dim)
+    agent = Agent(store, chunker=SentenceWindowChunker())
+
+    for turn in sample["turns"]:
+        if isinstance(turn, dict):
+            text = turn.get("text") or next(iter(turn.values()))
+        else:
+            text = str(turn)
+        agent.add_memory(text)
+        emb = enc.encode(text)
+        mgr.add_turn(ConversationTurn(text=text, turn_embedding=emb.tolist()))
+
+    query = sample["query"]
+    answer = sample.get("answer", "")
+    reply, info = agent.process_conversational_turn(query, mgr)
+    score = _simple_f1(answer, reply)
+    tokens = info.get("prompt_tokens", 0)
+    return {"score": score, "prompt_tokens": tokens}
+
+
+def run_response_experiment(config: ResponseExperimentConfig) -> List[Dict[str, Any]]:
+    """Run the experiment defined by ``config``."""
+
+    dataset = _load_dataset(config.dataset)
+    enc = MockEncoder()
+    results = []
+    for params in config.param_grid:
+        total_score = 0.0
+        total_tokens = 0
+        for sample in dataset:
+            res = _evaluate_sample(sample, params, enc)
+            total_score += res["score"]
+            total_tokens += res["prompt_tokens"]
+        n = len(dataset) or 1
+        results.append(
+            {
+                "params": params,
+                "avg_f1": total_score / n,
+                "avg_prompt_tokens": total_tokens / n,
+            }
+        )
+    return results
+
+
+__all__ = ["ResponseExperimentConfig", "run_response_experiment"]
+

--- a/tests/data/response_dialogues.yaml
+++ b/tests/data/response_dialogues.yaml
@@ -1,0 +1,12 @@
+- turns:
+    - user: "Remember that module B depends on A."
+    - assistant: "Okay."
+    - user: "Also C depends on B."
+    - assistant: "Understood."
+  query: "Which module does C depend on?"
+  answer: "B"
+- turns:
+    - user: "Set secret to 123."
+    - assistant: "Okay."
+  query: "What is secret?"
+  answer: "123"

--- a/tests/test_response_experiment.py
+++ b/tests/test_response_experiment.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import pytest
+
+from gist_memory.response_experiment import ResponseExperimentConfig, run_response_experiment
+from gist_memory.embedding_pipeline import MockEncoder
+
+
+@pytest.fixture(autouse=True)
+def use_mock_encoder(monkeypatch):
+    enc = MockEncoder()
+    monkeypatch.setattr("gist_memory.response_experiment.MockEncoder", lambda: enc)
+    monkeypatch.setattr("gist_memory.embedding_pipeline._load_model", lambda *a, **k: enc)
+    yield
+
+
+def test_response_experiment_runs(monkeypatch, tmp_path):
+    data = Path(__file__).parent / "data" / "response_dialogues.yaml"
+
+    class DummyLLM:
+        def __init__(self, *a, **k):
+            pass
+
+        tokenizer = staticmethod(lambda text, return_tensors=None, truncation=None, max_length=None: {"input_ids": text.split()})
+        model = type("M", (), {"config": type("C", (), {"n_positions": 50})()})()
+        max_new_tokens = 10
+
+        def prepare_prompt(self, agent, prompt, **kw):
+            DummyLLM.prompt = prompt
+            return prompt
+
+        def reply(self, prompt):
+            if "module" in prompt:
+                return "B"
+            if "secret" in prompt:
+                return "123"
+            return ""
+
+    monkeypatch.setattr("gist_memory.local_llm.LocalChatModel", DummyLLM)
+
+    params = [{"config_prompt_num_forced_recent_turns": 1}]
+    cfg = ResponseExperimentConfig(dataset=data, param_grid=params)
+    results = run_response_experiment(cfg)
+    assert len(results) == 1
+    res = results[0]
+    assert "avg_f1" in res and "avg_prompt_tokens" in res


### PR DESCRIPTION
## Summary
- extend `Agent.process_conversational_turn` to report prompt token count
- add new `response_experiment` module for end-to-end evaluation
- provide simple dataset for response experiments
- test the new experiment runner

## Testing
- `pytest -q tests/test_response_experiment.py`
- `pytest -q` *(fails: KeyboardInterrupt during long run, but 96 tests passed before interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683b349f331c83299705912c49011d0e