### PR TITLE
Fix get_statistics for ephemeral stores

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -147,13 +147,15 @@ class Agent:
 
         from .utils import get_disk_usage
 
-        path = Path(self.store.path)
+        path_value = self.store.path
+        path = Path(path_value) if path_value else None
+        disk_usage = get_disk_usage(path) if path is not None else 0
         return {
             "prototypes": len(self.store.prototypes),
             "memories": len(self.store.memories),
             "tau": self.similarity_threshold,
             "updated": self.store.meta.get("updated_at"),
-            "disk_usage": get_disk_usage(path),
+            "disk_usage": disk_usage,
         }
 
     # ------------------------------------------------------------------

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -166,3 +166,11 @@ def test_prompt_budget_truncates_prompt(monkeypatch, tmp_path):
     assert "one two" in Dummy.prompt
     assert "three" not in Dummy.prompt
 
+
+def test_get_statistics_ephemeral_store(tmp_path):
+    store = JsonNpyVectorStore(path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim)
+    store.path = None
+    agent = Agent(store, chunker=SentenceWindowChunker())
+    stats = agent.get_statistics()
+    assert stats["disk_usage"] == 0
+


### PR DESCRIPTION
## Summary
- handle agents with vector stores that have no path
- test statistics on an ephemeral store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b4816d10c8329b106c17fe80f9b15