### PR TITLE
Refactor for DRY principles

### DIFF
--- a/examples/onboarding_demo.py
+++ b/examples/onboarding_demo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import os
 
 from gist_memory import Agent, JsonNpyVectorStore
-from gist_memory.embedding_pipeline import embed_text
+from gist_memory.embedding_pipeline import embed_text, get_embedding_dim
 from gist_memory.config import DEFAULT_BRAIN_PATH
 
 os.environ.setdefault("HF_HUB_OFFLINE", "1")
@@ -18,7 +18,7 @@ def main() -> None:
     if (path / "meta.yaml").exists():
         store = JsonNpyVectorStore(str(path))
     else:
-        dim = int(embed_text(["dim"]).shape[1])
+        dim = get_embedding_dim()
         store = JsonNpyVectorStore(
             str(path), embedding_model="all-MiniLM-L6-v2", embedding_dim=dim
         )

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -14,7 +14,7 @@ from .logging_utils import configure_logging
 
 from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
-from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
+from .embedding_pipeline import get_embedding_dim, EmbeddingDimensionMismatchError
 from .utils import load_agent
 from .config import DEFAULT_BRAIN_PATH
 
@@ -98,7 +98,7 @@ def init(
         )
         raise typer.Exit(code=1)
     try:
-        dim = int(embed_text(["dim"]).shape[1])
+        dim = get_embedding_dim()
     except RuntimeError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)

--- a/gist_memory/embedding_pipeline.py
+++ b/gist_memory/embedding_pipeline.py
@@ -142,6 +142,19 @@ def embed_text(
     return np.stack(vecs)
 
 
+def get_embedding_dim(model_name: str = _MODEL_NAME, device: str = _DEVICE) -> int:
+    """Return the embedding dimension for ``model_name`` on ``device``."""
+
+    model = _load_model(model_name, device)
+    get_dim = getattr(model, "get_sentence_embedding_dimension", None)
+    if callable(get_dim):
+        return int(get_dim())
+    dim = getattr(model, "dim", None)
+    if isinstance(dim, int):
+        return dim
+    raise AttributeError("embedding dimension not found")
+
+
 def register_embedding(name: str, encoder_callable) -> None:
     """Allow plugins to register alternative embedding functions."""
     globals()[name] = encoder_callable
@@ -151,5 +164,6 @@ __all__ = [
     "EmbeddingDimensionMismatchError",
     "MockEncoder",
     "embed_text",
+    "get_embedding_dim",
     "register_embedding",
 ]

--- a/gist_memory/experiment_runner.py
+++ b/gist_memory/experiment_runner.py
@@ -11,7 +11,7 @@ from .json_npy_store import JsonNpyVectorStore
 from .active_memory_manager import ActiveMemoryManager
 from .chunker import Chunker, SentenceWindowChunker
 from .memory_creation import MemoryCreator, ExtractiveSummaryCreator
-from .embedding_pipeline import embed_text
+from .embedding_pipeline import embed_text, get_embedding_dim
 
 
 @dataclass
@@ -30,7 +30,7 @@ def run_experiment(config: ExperimentConfig) -> Dict[str, Any]:
     """Ingest ``config.dataset`` and return metrics."""
 
     work = config.work_dir or Path(tempfile.mkdtemp())
-    dim = int(embed_text(["dim"]).shape[1])
+    dim = get_embedding_dim()
     store = JsonNpyVectorStore(
         path=str(work), embedding_model="experiment", embedding_dim=dim
     )

--- a/gist_memory/talk_session.py
+++ b/gist_memory/talk_session.py
@@ -11,11 +11,6 @@ from .active_memory_manager import ActiveMemoryManager
 from .utils import load_agent
 
 
-def _load_agent(path: Path) -> Agent:
-    """Load a persisted agent from ``path``."""
-    return load_agent(path)
-
-
 @dataclass
 class TalkSession:
     session_id: str
@@ -42,7 +37,7 @@ class TalkSessionManager:
         managers: Dict[str, ActiveMemoryManager] = {}
         for p in agent_paths:
             path = Path(p)
-            agents[str(path)] = _load_agent(path)
+            agents[str(path)] = load_agent(path)
             managers[str(path)] = ActiveMemoryManager()
         self._sessions[sid] = TalkSession(
             session_id=sid,
@@ -104,7 +99,7 @@ class TalkSessionManager:
         key = str(path)
         if key in session.agents:
             return
-        agent = _load_agent(path)
+        agent = load_agent(path)
         for _sender, msg, _ts in session.log:
             agent.add_memory(msg)
         session.agents[key] = agent

--- a/gist_memory/tui/app.py
+++ b/gist_memory/tui/app.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ..agent import Agent
 from ..json_npy_store import JsonNpyVectorStore
 from ..config import DEFAULT_BRAIN_PATH
-from ..embedding_pipeline import embed_text
+from ..embedding_pipeline import get_embedding_dim
 from ..talk_session import TalkSessionManager
 
 from .helpers import _install_models
@@ -31,7 +31,7 @@ def run_tui(path: str = DEFAULT_BRAIN_PATH) -> None:
             ) from exc
     else:
         try:
-            dim = int(embed_text(["dim"]).shape[1])
+            dim = get_embedding_dim()
         except RuntimeError as exc:
             raise RuntimeError(str(exc)) from exc
         store = JsonNpyVectorStore(str(store_path), embedding_dim=dim)

--- a/gist_memory/utils.py
+++ b/gist_memory/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Iterable, List
 
 from .json_npy_store import JsonNpyVectorStore
 from .chunker import SentenceWindowChunker, _CHUNKER_REGISTRY
-from .embedding_pipeline import embed_text, EmbeddingDimensionMismatchError
+from .embedding_pipeline import get_embedding_dim, EmbeddingDimensionMismatchError
 
 
 def get_disk_usage(path: Path) -> int:
@@ -41,7 +41,8 @@ def load_agent(path: Path) -> Agent:
             f"Agent directory '{path}' not found or is invalid"
         ) from exc
     except EmbeddingDimensionMismatchError:
-        dim = int(embed_text(["dim"]).shape[1])
+        from .embedding_pipeline import get_embedding_dim
+        dim = get_embedding_dim()
         store = JsonNpyVectorStore(path=str(path), embedding_dim=dim)
 
     chunker_id = store.meta.get("chunker", "sentence_window")


### PR DESCRIPTION
## Summary
- add `get_embedding_dim` helper to `embedding_pipeline`
- use helper in CLI, TUI, utils, experiment runner and examples
- simplify `TalkSessionManager` by using existing `load_agent`
- update tests to pass with new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b517516908329bb3ed477042ddcf0