### PR TITLE
Add HTML repr methods for objects

### DIFF
--- a/gist_memory/json_npy_store.py
+++ b/gist_memory/json_npy_store.py
@@ -226,3 +226,21 @@ class JsonNpyVectorStore(VectorStore):
 
     def add_memory(self, memory: RawMemory) -> None:
         self.memories.append(memory)
+
+    # ------------------------------------------------------------------
+    def _repr_html_(self) -> str:
+        """Return HTML summary for notebooks."""
+        meta_items = """<tr><th>Embedding model</th><td>{model}</td></tr>
+<tr><th>Dimension</th><td>{dim}</td></tr>
+<tr><th>Normalized</th><td>{norm}</td></tr>
+<tr><th>Prototypes</th><td>{pcount}</td></tr>
+<tr><th>Memories</th><td>{mcount}</td></tr>
+<tr><th>Path</th><td>{path}</td></tr>""".format(
+            model=self.embedding_model,
+            dim=self.embedding_dim,
+            norm=self.normalized,
+            pcount=len(self.prototypes),
+            mcount=len(self.memories),
+            path=self.path,
+        )
+        return f"<table>{meta_items}</table>"

--- a/gist_memory/models.py
+++ b/gist_memory/models.py
@@ -23,6 +23,28 @@ class BeliefPrototype(BaseModel):
     )
     constituent_memory_ids: List[str] = Field(default_factory=list)
 
+    # --------------------------------------------------------------
+    def _repr_html_(self) -> str:
+        """Return a rich HTML representation for Jupyter."""
+        rows = """
+        <tr><th>Prototype ID</th><td>{pid}</td></tr>
+        <tr><th>Strength</th><td>{strength:.2f}</td></tr>
+        <tr><th>Confidence</th><td>{conf:.2f}</td></tr>
+        <tr><th>Summary</th><td>{summary}</td></tr>
+        <tr><th>Memories</th><td>{num}</td></tr>
+        <tr><th>Created</th><td>{created}</td></tr>
+        <tr><th>Updated</th><td>{updated}</td></tr>
+        """.format(
+            pid=self.prototype_id,
+            strength=self.strength,
+            conf=self.confidence,
+            summary=self.summary_text,
+            num=len(self.constituent_memory_ids),
+            created=self.creation_ts.isoformat(),
+            updated=self.last_updated_ts.isoformat(),
+        )
+        return f"<table>{rows}</table>"
+
     @field_validator("summary_text")
     def _limit_summary(cls, v: str) -> str:
         if len(v) > 256:


### PR DESCRIPTION
## Summary
- implement `_repr_html_` for `BeliefPrototype`
- implement `_repr_html_` for `JsonNpyVectorStore`
- introduce `QueryResult` dict subclass with HTML representation
- implement `_repr_html_` and updated return type in `Agent`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_683b798050f48329a689353b96f83e80