### PR TITLE
Add runtime reconfiguration for Agent

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -116,9 +116,13 @@ class Agent:
         if not 0.5 <= similarity_threshold <= 0.95:
             raise ValueError("similarity_threshold must be between 0.5 and 0.95")
         self.store = store
-        self.chunker = chunker or SentenceWindowChunker()
-        self.similarity_threshold = similarity_threshold
-        self.summary_creator = summary_creator or ExtractiveSummaryCreator(max_words=25)
+        self._chunker: Chunker = chunker or SentenceWindowChunker()
+        self.store.meta["chunker"] = getattr(self._chunker, "id", type(self._chunker).__name__)
+        self._similarity_threshold = float(similarity_threshold)
+        self.store.meta["tau"] = self._similarity_threshold
+        self._summary_creator: MemoryCreator = (
+            summary_creator or ExtractiveSummaryCreator(max_words=25)
+        )
         self.update_summaries = update_summaries
         self.metrics: Dict[str, int] = {
             "memories_ingested": 0,
@@ -140,6 +144,63 @@ class Agent:
         self._conflict_logger = SimpleConflictLogger(c)
         self._conflicts = ConflictFlagger(FlagLogger(c))
         self.prompt_budget = prompt_budget
+
+    # ------------------------------------------------------------------
+    @property
+    def chunker(self) -> Chunker:
+        """Return the current :class:`Chunker`."""
+
+        return self._chunker
+
+    @chunker.setter
+    def chunker(self, value: Chunker) -> None:
+        if not isinstance(value, Chunker):
+            raise TypeError("chunker must implement Chunker interface")
+        self._chunker = value
+        self.store.meta["chunker"] = getattr(value, "id", type(value).__name__)
+
+    # ------------------------------------------------------------------
+    @property
+    def similarity_threshold(self) -> float:
+        return self._similarity_threshold
+
+    @similarity_threshold.setter
+    def similarity_threshold(self, value: float) -> None:
+        if not 0.5 <= value <= 0.95:
+            raise ValueError("similarity_threshold must be between 0.5 and 0.95")
+        self._similarity_threshold = float(value)
+        self.store.meta["tau"] = self._similarity_threshold
+
+    # ------------------------------------------------------------------
+    @property
+    def summary_creator(self) -> MemoryCreator:
+        return self._summary_creator
+
+    @summary_creator.setter
+    def summary_creator(self, value: MemoryCreator) -> None:
+        if not isinstance(value, MemoryCreator):
+            raise TypeError("summary_creator must implement MemoryCreator")
+        self._summary_creator = value
+
+    # ------------------------------------------------------------------
+    def configure(
+        self,
+        *,
+        chunker: Chunker | None = None,
+        similarity_threshold: float | None = None,
+        summary_creator: MemoryCreator | None = None,
+        prompt_budget: PromptBudget | None = None,
+    ) -> None:
+        """Dynamically update core configuration."""
+
+        if chunker is not None:
+            self.chunker = chunker
+        if similarity_threshold is not None:
+            self.similarity_threshold = similarity_threshold
+        if summary_creator is not None:
+            self.summary_creator = summary_creator
+        if prompt_budget is not None:
+            self.prompt_budget = prompt_budget
 
     # ------------------------------------------------------------------
     def get_statistics(self) -> Dict[str, object]:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7,7 +7,7 @@ from gist_memory import agent as ag
 from gist_memory.agent import Agent
 from gist_memory.embedding_pipeline import MockEncoder, _load_model, embed_text
 from gist_memory.json_npy_store import JsonNpyVectorStore
-from gist_memory.chunker import SentenceWindowChunker
+from gist_memory.chunker import SentenceWindowChunker, Chunker
 from gist_memory.active_memory_manager import ActiveMemoryManager
 from gist_memory.prompt_budget import PromptBudget
 
@@ -173,4 +173,36 @@ def test_get_statistics_ephemeral_store(tmp_path):
     agent = Agent(store, chunker=SentenceWindowChunker())
     stats = agent.get_statistics()
     assert stats["disk_usage"] == 0
+
+
+class DummyChunker(Chunker):
+    id = "dummy"
+
+    def chunk(self, text: str) -> list[str]:
+        return [f"dummy:{text}"]
+
+
+def test_reconfigure_chunker(tmp_path):
+    store = JsonNpyVectorStore(path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim)
+    agent = Agent(store, chunker=SentenceWindowChunker())
+    agent.add_memory("alpha")
+    agent.chunker = DummyChunker()
+    agent.add_memory("bravo")
+    assert store.memories[-1].raw_text == "dummy:bravo"
+    assert store.meta["chunker"] == "dummy"
+
+
+def test_reconfigure_similarity_threshold(tmp_path, monkeypatch):
+    store = JsonNpyVectorStore(path=str(tmp_path), embedding_model="mock", embedding_dim=MockEncoder.dim)
+    agent = Agent(store, chunker=SentenceWindowChunker())
+    agent.add_memory("alpha")
+
+    def fake_nearest(vec, k=1):
+        return [(store.prototypes[0].prototype_id, 0.6)]
+
+    monkeypatch.setattr(store, "find_nearest", fake_nearest)
+    agent.similarity_threshold = 0.5
+    res = agent.add_memory("bravo")[0]
+    assert res["spawned"] is False
+    assert store.meta["tau"] == 0.5
 


### PR DESCRIPTION
## Summary
- allow Agent settings like similarity threshold, chunker and summary creator to be changed after creation
- expose `configure()` helper and property setters
- record updates in the store metadata
- test dynamic reconfiguration of chunker and similarity threshold

## Testing
- `pytest tests/test_agent.py::test_reconfigure_chunker tests/test_agent.py::test_reconfigure_similarity_threshold -q`
- `pytest -q` *(full test suite was run earlier and passed)*

------
https://chatgpt.com/codex/tasks/task_e_683b799f99908329b4e89e8f7675d448