### PR TITLE
Add explicit model load/unload helpers

### DIFF
--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -104,8 +104,9 @@ def test_local_chat_model_failure(monkeypatch):
         "gist_memory.local_llm.AutoModelForCausalLM.from_pretrained", err
     )
 
+    model = LocalChatModel(model_name="foo")
     with pytest.raises(RuntimeError) as exc:
-        LocalChatModel(model_name="foo")
+        model.load_model()
     msg = str(exc.value)
     assert "download-chat-model" in msg
     assert "foo" in msg


### PR DESCRIPTION
## Summary
- expose `load_model`/`unload_model` functions and context manager for embedding models
- allow `LocalChatModel` to load lazily with new helpers and context manager
- update tests for new loading behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b7a504d688329adbf83745dfada38