### PR TITLE
Support notebook progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ gist-memory clear --yes
 
 Additional functions such as decoding or summarising a prototype are
 available via the Python API.
+When working in a Jupyter notebook you can display a progress bar during
+ingestion by passing ``tqdm_notebook=True`` to ``Agent.add_memory``.
 
 The local embedder loads the model from the Hugging Face cache only and will not
 attempt any network downloads. Ensure the embedding and chat models are


### PR DESCRIPTION
## Summary
- enable optional tqdm notebook progress bars in `Agent.add_memory`
- document the new feature in the README
- test notebook progress integration

## Testing
- `pytest -q tests/test_agent.py::test_add_memory_tqdm_notebook`

------
https://chatgpt.com/codex/tasks/task_e_683b7a2135ac8329ab45f4de4e556f2a