### PR TITLE
Add library log level helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Prototype implementation of the Gist Memory Agent using a coarse prototype memor
 - Python API provides helpers to decode and summarise prototypes.
 - Chat with a brain using a local LLM via the `talk` command.
 - Enable debug logging with `--log-file`.
+- Library log level can be adjusted programmatically via ``set_library_log_level``.
 - Conflicts are heuristically flagged and written to `conflicts.jsonl` for
   HITL review.
 

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+from .logging_utils import get_library_logger, set_library_log_level
+
 __all__ = [
     "app",
     "BeliefPrototype",
@@ -36,6 +38,8 @@ __all__ = [
     "tokenize_text",
     "token_count",
     "PromptBudget",
+    "get_library_logger",
+    "set_library_log_level",
 ]
 
 _lazy_map = {

--- a/gist_memory/__main__.py
+++ b/gist_memory/__main__.py
@@ -9,7 +9,7 @@ try:  # optional pretty tracebacks
 except Exception:  # pragma: no cover - rich may not be installed
     pass
 
-from .logging_utils import configure_logging
+from .logging_utils import configure_logging, set_library_log_level
 
 
 def main(argv=None) -> None:
@@ -34,6 +34,8 @@ def main(argv=None) -> None:
     if log_file:
         level = logging.DEBUG if verbose else logging.INFO
         configure_logging(Path(log_file), level)
+    elif verbose:
+        set_library_log_level(logging.DEBUG, add_basic_handler=True)
 
     sys.argv = [sys.argv[0]] + args
 

--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -10,6 +10,8 @@ from .token_utils import token_count
 import numpy as np
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class ConversationTurn:
@@ -157,7 +159,7 @@ class ActiveMemoryManager:
         selected_older.sort(key=lambda t: self.history.index(t))
 
         selected = selected_older + list(recent_slice)
-        logging.debug(
+        logger.debug(
             "[prompt] select_history candidates=%d recent=%d older=%d",
             len(selected),
             len(recent_slice),

--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, TypedDict, Callable
 import logging
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
 
 from .chunker import Chunker, SentenceWindowChunker
 from .embedding_pipeline import embed_text
@@ -322,7 +324,7 @@ class Agent:
                 "status": "no_match",
             }
 
-        logging.info(
+        logger.info(
             "[query] '%s' → %d protos, top sim %.2f",
             text[:40],
             len(nearest),
@@ -384,7 +386,7 @@ class Agent:
         candidate_tokens = token_count(
             llm.tokenizer, "\n".join(t.text for t in history_candidates)
         )
-        logging.debug(
+        logger.debug(
             "[prompt] history candidates=%d tokens=%d",
             len(history_candidates),
             candidate_tokens,
@@ -435,7 +437,7 @@ class Agent:
 
         history_text = "\n".join(t.text for t in history_final)
         history_tokens_final = token_count(llm.tokenizer, history_text)
-        logging.debug(
+        logger.debug(
             "[prompt] history after fit turns=%d tokens=%d",
             len(history_final),
             history_tokens_final,
@@ -452,20 +454,20 @@ class Agent:
                 f"Context: {mem_texts}" if mem_texts else "",
             ]
         ).strip()
-        logging.debug(
+        logger.debug(
             "[prompt] LTM snippets tokens before=%d",
             token_count(llm.tokenizer, ltm_initial) if ltm_initial else 0,
         )
 
         user_text = input_message
         if b_query:
-            logging.debug(
+            logger.debug(
                 "[prompt] query tokens before=%d limit=%s",
                 token_count(llm.tokenizer, user_text),
                 b_query,
             )
             user_text = truncate_text(llm.tokenizer, user_text, b_query)
-            logging.debug(
+            logger.debug(
                 "[prompt] query tokens after=%d",
                 token_count(llm.tokenizer, user_text),
             )
@@ -477,13 +479,13 @@ class Agent:
             ltm_parts.append(f"Context: {mem_texts}")
         ltm_text = "\n".join(ltm_parts)
         if b_ltm:
-            logging.debug(
+            logger.debug(
                 "[prompt] LTM tokens before=%d limit=%s",
                 token_count(llm.tokenizer, ltm_text),
                 b_ltm,
             )
             ltm_text = truncate_text(llm.tokenizer, ltm_text, b_ltm)
-            logging.debug(
+            logger.debug(
                 "[prompt] LTM tokens after=%d",
                 token_count(llm.tokenizer, ltm_text),
             )
@@ -497,10 +499,10 @@ class Agent:
         parts.append("Answer:")
         prompt = "\n".join(parts)
         before_llm_tokens = token_count(llm.tokenizer, prompt)
-        logging.debug("[prompt] before prepare tokens=%d", before_llm_tokens)
+        logger.debug("[prompt] before prepare tokens=%d", before_llm_tokens)
         prompt = llm.prepare_prompt(self, prompt)
         after_llm_tokens = token_count(llm.tokenizer, prompt)
-        logging.debug("[prompt] after prepare tokens=%d", after_llm_tokens)
+        logger.debug("[prompt] after prepare tokens=%d", after_llm_tokens)
         prompt_tokens = after_llm_tokens
         reply = llm.reply(prompt)
 
@@ -534,7 +536,7 @@ class Agent:
         lightweight observability for higher level session management code.
         """
 
-        logging.info("[receive] from %s: %s", source_id, message_text[:40])
+        logger.info("[receive] from %s: %s", source_id, message_text[:40])
 
         summary: dict[str, object] = {"source": source_id}
 
@@ -574,7 +576,7 @@ class Agent:
                 prompt = llm.prepare_prompt(self, prompt)
                 reply = llm.reply(prompt)
             except Exception as exc:  # pragma: no cover - optional dep
-                logging.warning("chat reply failed: %s", exc)
+                logger.warning("chat reply failed: %s", exc)
                 reply = None
 
             summary["reply"] = reply

--- a/gist_memory/chunker.py
+++ b/gist_memory/chunker.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+logger = logging.getLogger(__name__)
 from abc import ABC, abstractmethod
 from typing import Dict, List, Type
 
@@ -64,7 +66,7 @@ class SentenceWindowChunker(Chunker):
             else:
                 tokens = sent.split()
             if len(tokens) > self.max_tokens:
-                logging.warning("long sentence split")
+                logger.warning("long sentence split")
                 for i in range(0, len(tokens), self.max_tokens):
                     sub = tokens[i : i + self.max_tokens]
                     if current:

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -9,7 +9,7 @@ import portalocker
 from rich.table import Table
 from rich.console import Console
 
-from .logging_utils import configure_logging
+from .logging_utils import configure_logging, set_library_log_level
 
 
 from .agent import Agent
@@ -36,7 +36,7 @@ def main(
         level = logging.DEBUG if verbose else logging.INFO
         configure_logging(log_file, level)
     elif verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        set_library_log_level(logging.DEBUG, add_basic_handler=True)
     global VERBOSE
     VERBOSE = verbose
     ctx.obj = {"verbose": verbose}

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import inspect
 import logging
+
+logger = logging.getLogger(__name__)
 from typing import Optional, TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
@@ -178,17 +180,17 @@ class LocalChatModel:
 
         max_len = self._context_length()
         input_tokens = token_count(self.tokenizer, prompt)
-        logging.debug("[prepare_prompt] input tokens=%d max=%d", input_tokens, max_len)
+        logger.debug("[prepare_prompt] input tokens=%d max=%d", input_tokens, max_len)
         tokens = self.tokenizer(prompt, return_tensors="pt")["input_ids"][0]
         if input_tokens <= max_len:
-            logging.debug("[prepare_prompt] no truncation needed")
+            logger.debug("[prepare_prompt] no truncation needed")
             return prompt
 
         old_tokens = tokens[:-recent_tokens]
         recent_tokens_ids = tokens[-recent_tokens:]
         old_text = self.tokenizer.decode(old_tokens, skip_special_tokens=True)
         recent_text = self.tokenizer.decode(recent_tokens_ids, skip_special_tokens=True)
-        logging.debug(
+        logger.debug(
             "[prepare_prompt] old=%d recent=%d", len(old_tokens), len(recent_tokens_ids)
         )
 
@@ -209,7 +211,7 @@ class LocalChatModel:
 
         output = recap_text + recent_text
         output_tokens = token_count(self.tokenizer, output)
-        logging.debug(
+        logger.debug(
             "[prepare_prompt] output tokens=%d (recap=%d recent=%d)",
             output_tokens,
             token_count(self.tokenizer, recap_text),

--- a/gist_memory/logging_utils.py
+++ b/gist_memory/logging_utils.py
@@ -2,6 +2,31 @@ import logging
 from pathlib import Path
 
 
+def get_library_logger() -> logging.Logger:
+    """Return the root logger for the ``gist_memory`` package."""
+    return logging.getLogger("gist_memory")
+
+
+def set_library_log_level(level: int, *, add_basic_handler: bool = False) -> None:
+    """Set the log level for the ``gist_memory`` logger.
+
+    Parameters
+    ----------
+    level:
+        Logging verbosity level.
+    add_basic_handler:
+        When ``True`` and the root logger has no handlers, ``logging.basicConfig``
+        will be called so log messages appear on ``stderr``.  This is handy in
+        simple scripts or notebooks.
+    """
+
+    logger = get_library_logger()
+    logger.setLevel(level)
+
+    if add_basic_handler and not logging.getLogger().handlers:
+        logging.basicConfig(level=level)
+
+
 def configure_logging(log_file: Path, level: int = logging.INFO) -> None:
     """Configure Python logging to write to ``log_file``."""
     if not log_file.parent.exists():
@@ -9,9 +34,9 @@ def configure_logging(log_file: Path, level: int = logging.INFO) -> None:
     handler = logging.FileHandler(str(log_file))
     handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
-    root = logging.getLogger()
-    root.setLevel(level)
-    root.addHandler(handler)
+    logger = get_library_logger()
+    logger.setLevel(level)
+    logger.addHandler(handler)
 
 
-__all__ = ["configure_logging"]
+__all__ = ["configure_logging", "get_library_logger", "set_library_log_level"]


### PR DESCRIPTION
## Summary
- allow easy access to gist-memory logging via `get_library_logger` and `set_library_log_level`
- use these helpers in CLI and `__main__`
- update modules to use module-level loggers
- add `add_basic_handler` option to `set_library_log_level` and document in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b7a370c188329b20239ad14a92153