### PR TITLE
Define compression strategy ABC

### DIFF
--- a/gist_memory/compression/__init__.py
+++ b/gist_memory/compression/__init__.py
@@ -1,0 +1,5 @@
+"""Compression strategy interfaces and implementations."""
+
+from .strategies_abc import CompressedMemory, CompressionStrategy
+
+__all__ = ["CompressedMemory", "CompressionStrategy"]

--- a/gist_memory/compression/strategies_abc.py
+++ b/gist_memory/compression/strategies_abc.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Abstract interface for memory compression strategies."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, List, Union, Any, Optional
+
+
+@dataclass
+class CompressedMemory:
+    """Simple container for compressed memory text and metadata."""
+
+    text: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class CompressionStrategy(ABC):
+    """Interface for memory compression algorithms."""
+
+    id: str
+
+    @abstractmethod
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int,
+        **kwargs: Any,
+    ) -> CompressedMemory:
+        """Return compressed form of ``text_or_chunks`` within ``llm_token_budget``."""
+
+
+__all__ = ["CompressedMemory", "CompressionStrategy"]

--- a/tests/test_compression_strategies.py
+++ b/tests/test_compression_strategies.py
@@ -1,0 +1,20 @@
+from gist_memory.compression import CompressionStrategy, CompressedMemory
+
+
+class DummyStrategy(CompressionStrategy):
+    id = "dummy"
+
+    def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+        if isinstance(text_or_chunks, list):
+            text = " ".join(text_or_chunks)
+        else:
+            text = text_or_chunks
+        return CompressedMemory(text=text[:llm_token_budget])
+
+
+def test_dummy_strategy():
+    strat = DummyStrategy()
+    result = strat.compress(["alpha", "bravo"], llm_token_budget=10)
+    assert isinstance(result, CompressedMemory)
+    assert result.text == "alpha bravo"[:10]
+


### PR DESCRIPTION
## Summary
- add compression module with abstract base class
- export `CompressedMemory` and `CompressionStrategy`
- basic test for compression strategy subclass

## Testing
- `pytest tests/test_compression_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5a58df648329b5e37d862908a12d