### PR TITLE
Add ValidationMetric ABC

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "tokenize_text",
     "token_count",
     "PromptBudget",
+    "ValidationMetric",
 ]
 
 _lazy_map = {
@@ -71,6 +72,7 @@ _lazy_map = {
     "tokenize_text": "gist_memory.token_utils",
     "token_count": "gist_memory.token_utils",
     "PromptBudget": "gist_memory.prompt_budget",
+    "ValidationMetric": "gist_memory.validation.metrics_abc",
 }
 
 

--- a/gist_memory/validation/metrics_abc.py
+++ b/gist_memory/validation/metrics_abc.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Abstract base class for validation metrics."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from ..memory_creation import CompressedMemoryObject
+else:  # pragma: no cover - avoid runtime dependency
+    CompressedMemoryObject = Any
+
+
+class ValidationMetric(ABC):
+    """Interface for evaluating compression strategies and LLM responses."""
+
+    @abstractmethod
+    def evaluate(
+        self,
+        original_query: str,
+        llm_response: str,
+        compressed_context: CompressedMemoryObject,
+        reference_data: Any,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Return metric results as a dictionary."""


### PR DESCRIPTION
## Summary
- add `ValidationMetric` abstract class for evaluating compression
- expose `ValidationMetric` via package API

## Testing
- `flake8 gist_memory/validation/metrics_abc.py gist_memory/__init__.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683c5aa5ef808329b7f73639816e3384