### PR TITLE
Add plugin registries for compression strategies and metrics

### DIFF
--- a/gist_memory/registry.py
+++ b/gist_memory/registry.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Plugin registries for compression strategies and validation metrics."""
+
+from typing import Dict, Type
+
+
+class CompressionStrategy:
+    """Base interface for text compression strategies."""
+
+    id: str
+
+    def compress(self, text: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ValidationMetric:
+    """Base interface for evaluating predictions."""
+
+    id: str
+
+    def compute(self, reference: str, prediction: str) -> float:  # pragma: no cover
+        raise NotImplementedError
+
+
+_COMPRESSION_REGISTRY: Dict[str, Type[CompressionStrategy]] = {}
+_VALIDATION_REGISTRY: Dict[str, Type[ValidationMetric]] = {}
+
+
+def register_compression_strategy(id: str, strategy_class: Type[CompressionStrategy]) -> None:
+    """Register ``strategy_class`` under ``id``."""
+
+    _COMPRESSION_REGISTRY[id] = strategy_class
+
+
+def register_validation_metric(id: str, metric_class: Type[ValidationMetric]) -> None:
+    """Register ``metric_class`` under ``id``."""
+
+    _VALIDATION_REGISTRY[id] = metric_class
+
+
+__all__ = [
+    "CompressionStrategy",
+    "ValidationMetric",
+    "register_compression_strategy",
+    "register_validation_metric",
+    "_COMPRESSION_REGISTRY",
+    "_VALIDATION_REGISTRY",
+]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,30 @@
+from gist_memory.registry import (
+    CompressionStrategy,
+    ValidationMetric,
+    register_compression_strategy,
+    register_validation_metric,
+    _COMPRESSION_REGISTRY,
+    _VALIDATION_REGISTRY,
+)
+
+
+def test_register_compression_strategy():
+    class DummyStrategy(CompressionStrategy):
+        id = "dummy"
+
+        def compress(self, text: str) -> str:
+            return text
+
+    register_compression_strategy(DummyStrategy.id, DummyStrategy)
+    assert _COMPRESSION_REGISTRY["dummy"] is DummyStrategy
+
+
+def test_register_validation_metric():
+    class DummyMetric(ValidationMetric):
+        id = "metric"
+
+        def compute(self, reference: str, prediction: str) -> float:
+            return 0.0
+
+    register_validation_metric(DummyMetric.id, DummyMetric)
+    assert _VALIDATION_REGISTRY["metric"] is DummyMetric


### PR DESCRIPTION
## Summary
- create `registry.py` with registries for compression strategies and validation metrics
- add unit tests for registering plugins

## Testing
- `pytest -q tests/test_registry.py`
- `pytest -q` *(fails: KeyboardInterrupt while running full test suite)*

------
https://chatgpt.com/codex/tasks/task_e_683c5ab56d1083298d9fc1c1f30c2f37