### PR TITLE
Introduce generic experiment config

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -61,7 +61,7 @@ _lazy_map = {
     "ConflictFlagger": "gist_memory.conflict_flagging",
     "ConflictLogger": "gist_memory.conflict_flagging",
     "SimpleConflictLogger": "gist_memory.conflict",
-    "ExperimentConfig": "gist_memory.experiment_runner",
+    "ExperimentConfig": "gist_memory.experiments.config",
     "run_experiment": "gist_memory.experiment_runner",
     "HistoryExperimentConfig": "gist_memory.history_experiment",
     "run_history_experiment": "gist_memory.history_experiment",

--- a/gist_memory/experiment_runner.py
+++ b/gist_memory/experiment_runner.py
@@ -11,19 +11,8 @@ from .json_npy_store import JsonNpyVectorStore
 from .active_memory_manager import ActiveMemoryManager
 from .chunker import Chunker, SentenceWindowChunker
 from .memory_creation import MemoryCreator, ExtractiveSummaryCreator
+from .experiments.config import ExperimentConfig
 from .embedding_pipeline import embed_text, get_embedding_dim
-
-
-@dataclass
-class ExperimentConfig:
-    """Configuration for :func:`run_experiment`."""
-
-    dataset: Path
-    similarity_threshold: float = 0.8
-    chunker: Optional[Chunker] = None
-    summary_creator: Optional[MemoryCreator] = None
-    work_dir: Optional[Path] = None
-    active_memory_params: Optional[Dict[str, Any]] = None
 
 
 def run_experiment(config: ExperimentConfig) -> Dict[str, Any]:
@@ -65,3 +54,6 @@ def run_experiment(config: ExperimentConfig) -> Dict[str, Any]:
     )
     agent.store.save()
     return metrics
+
+
+__all__ = ["ExperimentConfig", "run_experiment"]

--- a/gist_memory/experiments/config.py
+++ b/gist_memory/experiments/config.py
@@ -1,0 +1,46 @@
+"""Configuration dataclasses for the experimentation framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional, Dict, List
+
+from ..chunker import Chunker
+from ..memory_creation import MemoryCreator
+
+
+DatasetLoader = Callable[[], Iterable[Any]]
+
+
+@dataclass
+class ExperimentConfig:
+    """Generic configuration for running experiments."""
+
+    # Either ``dataset`` or ``loader`` should be provided.
+    dataset: Optional[Path | str] = None
+    loader: Optional[DatasetLoader] = None
+
+    # Compression strategy identifier and its parameters
+    compression_strategy: str = "none"
+    compression_params: Dict[str, Any] = field(default_factory=dict)
+
+    # Legacy agent ingest options
+    similarity_threshold: float = 0.8
+    chunker: Optional[Chunker] = None
+    summary_creator: Optional[MemoryCreator] = None
+
+    # Details for the language model used during the experiment
+    llm_model: Optional[str] = None
+    llm_api_key: Optional[str] = None
+
+    # Validation metrics to compute and their individual configs
+    metrics: List[str] = field(default_factory=list)
+    metric_params: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    # Optional experiment specific settings from legacy experiments
+    work_dir: Optional[Path] = None
+    active_memory_params: Optional[Dict[str, Any]] = None
+
+
+__all__ = ["ExperimentConfig", "DatasetLoader"]


### PR DESCRIPTION
## Summary
- add new `ExperimentConfig` dataclass for upcoming experiment framework
- use new config in `run_experiment`
- expose new config through package init

## Testing
- `pytest tests/test_experiment_runner.py::test_run_experiment -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5aa86a5483298512d04f91734e61