### PR TITLE
Revise README and add docs for experimentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,174 +1,140 @@
-# Gist Memory Agent
+# Gist Memory: An Experimentation Platform for LLM Memory Compression
 
-Prototype implementation of the Gist Memory Agent using a coarse prototype memory system.
+**Gist Memory is a Python-based platform designed for rapidly prototyping, testing, and validating diverse strategies for compressing textual information ("memory") to maximize its utility within Large Language Model (LLM) token budgets.**
 
-## Features
+It provides a framework to implement and compare different approaches to making large text corpora or conversational history manageable and effective for LLMs.
 
-- CLI interface with `init`, `add`, `query`, `list-beliefs`, `stats`,
-  `validate`, `clear` and `download-model` commands.
-- Lightweight JSON/NPY backend for prototypes and memories (default).
-- Optional Chroma vector store for scale via ``pip install \"gist-memory[chroma]\"``.
-- Pluggable memory creation engines (identity, extractive, chunk, LLM summary, or agentic splitting).
-- Pluggable embedding backends: random (default), OpenAI, or local sentence-transformer.
-- Chunks are rendered using a canonical ``WHO/WHAT/WHEN/WHERE/WHY`` template before embedding.
-- The CLI runs smoothly in Colab.
-- A Colab notebook will provide an interactive GUI in the future.
-- Python API provides helpers to decode and summarise prototypes.
-- Chat with a brain using a local LLM via the `talk` command.
-- Enable debug logging with `--log-file`.
-- Conflicts are heuristically flagged and written to `conflicts.jsonl` for
-  HITL review.
+## Core Features
+
+* **Experimentation Framework:** Systematically test and validate memory compression strategies against defined datasets.
+* **Pluggable `CompressionStrategy` Interface:** Easily implement and integrate diverse memory processing techniques. Examples include:
+    * Active memory management (inspired by human working memory).
+    * Gist-based prototype systems for long-term knowledge consolidation.
+    * Extractive summarization, and more.
+* **Pluggable `ValidationMetric` Interface:** Define and apply custom metrics to evaluate the effectiveness of compressed memory in LLM interactions (e.g., information recall, F1 score, coherence).
+* **Command-Line Interface (CLI):** Manage experiments, test strategies, and interact with the system.
+* **Local LLM Interaction:** Test compressed memory with local LLMs for end-to-end validation.
+* **Flexible Storage Backend:** Includes a lightweight JSON/NPY backend for components of strategies that require persistence (like LTM prototypes). (ChromaDB support can be mentioned if it remains relevant for specific strategies).
+
+## Why Gist Memory?
+
+* **Researchers:** Benchmark and compare novel memory compression algorithms for LLMs.
+* **Developers:** Find the most effective way to fit large amounts of contextual data into limited LLM prompt windows for your application.
+* **Community:** Share and discover new techniques for efficient LLM memory management.
 
 ## Setup
 
-This project requires **Python 3.11+**.  Install the dependencies and download
-the default local embedding model (only needed the first time):
+This project requires **Python 3.11+**.
 
-```bash
-pip install -r requirements.txt
-# download the spaCy model for sentence segmentation
-python -m spacy download en_core_web_sm
-# fetch the "all-MiniLM-L6-v2" model so the local embedder works offline
-gist-memory download-model --model-name all-MiniLM-L6-v2
-# fetch the default chat model for talk mode
-gist-memory download-chat-model --model-name distilgpt2
-```
+1.  **Install Dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    # Download the spaCy model for sentence segmentation (used by some strategies/chunkers)
+    python -m spacy download en_core_web_sm
+    ```
 
-For a quick offline setup you can also run:
+2.  **Download Models for Testing (Optional but Recommended):**
+    These models are used by example strategies or for testing LLM interactions with compressed memory.
+    ```bash
+    # Fetch the "all-MiniLM-L6-v2" model for embedding (used by default LTM components)
+    gist-memory download-model --model-name all-MiniLM-L6-v2
+    # Fetch a default chat model for the 'talk' command and LLM-based validation
+    gist-memory download-chat-model --model-name distilgpt2
+    ```
+    To run completely offline after downloads, set:
+    ```
+    export HF_HUB_OFFLINE=1
+    export TRANSFORMERS_OFFLINE=1
+    ```
 
-```bash
-bash .codex/setup.sh
-```
-
-
-To run completely offline set:
-
-```
-export HF_HUB_OFFLINE=1
-export TRANSFORMERS_OFFLINE=1
-```
-Once installed, run `gist-memory --help` to see the available commands.
-
-Alternatively install the package from source:
-
+Alternatively, install the package from source:
 ```bash
 pip install .
 ```
+Run `gist-memory --help` to see available commands.
+
+## Core Workflow
+The platform facilitates the following general workflow:
+
+1. **Ingest Text:** Provide a large text corpus or conversational data.
+2. **Apply CompressionStrategy:** Choose and configure a strategy to process and compress the input text according to a specified token budget.
+3. **Prepare LLM Prompt:** Combine the compressed memory with a user query/task.
+4. **Interact with LLM:** Send the assembled prompt to an LLM.
+5. **Validate Results:** Apply chosen ValidationMetric(s) to the LLM's response and the compressed context to evaluate effectiveness.
 
 ## Usage
 
-### Command line
-
-Initialise a new brain then ingest a memory:
-
-```bash
-gist-memory init brain
-gist-memory add --text "Some text to remember"
-```
-
-When using the OpenAI embedder, set the ``OPENAI_API_KEY`` environment
-variable so the library can authenticate.
-
-You can also pass a path to a text file or a directory containing ``*.txt``
-files:
+### Running Experiments
+The primary way to use Gist Memory is through its experimentation framework.
 
 ```bash
-gist-memory add --file notes.txt
-gist-memory add --file docs/
+# Example: Run an experiment defined in a configuration file
+gist-memory experiment --config path/to/experiment_config.yaml
 ```
+(The CLI for experiment will need to be updated to accept CompressionStrategy, ValidationMetric, and their parameters).
+Refer to [docs/RUNNING_EXPERIMENTS.md](docs/RUNNING_EXPERIMENTS.md) for details on setting up and interpreting experiments.
 
-Query memories:
+### Developing New Strategies & Metrics
+Gist Memory is designed to be extensible:
 
+* **To create a new CompressionStrategy:** Implement the CompressionStrategy interface (see `gist_memory/compression/strategies_abc.py` - to be created) and register it.
+* **To create a new ValidationMetric:** Implement the ValidationMetric interface (see `gist_memory/validation/metrics_abc.py` - to be created) and register it.
+
+Detailed guides will be available in:
+
+* [docs/DEVELOPING_COMPRESSION_STRATEGIES.md](docs/DEVELOPING_COMPRESSION_STRATEGIES.md)
+* [docs/DEVELOPING_VALIDATION_METRICS.md](docs/DEVELOPING_VALIDATION_METRICS.md)
+
+### Basic CLI Interactions (for testing individual components)
+
+Initialize a "Brain" (for LTM-based strategies): Some strategies (like the prototype-based one) might require initializing a persistent store.
 ```bash
-gist-memory query --query-text "search text" --k-memories 5
+gist-memory init my_ltm_store # Optional, if your strategy needs it
 ```
 
-Chat with the entire brain using a local model:
-
+Test a Compression Strategy (New/Revised Command):
 ```bash
-gist-memory talk --message "What's in this brain?"
+gist-memory compress --strategy <strategy_name> --text "Your large text here..." --budget 500
 ```
-Ensure the chat model is pre-downloaded using `gist-memory download-chat-model`.
 
-List belief prototypes and show store stats:
-
+Chat with Compressed Memory (Revised Command): The talk command can be used to test how an LLM responds when provided with context from a specific compression strategy.
 ```bash
-gist-memory list-beliefs
-gist-memory stats
-gist-memory validate
-# permanently remove all data
-gist-memory clear --yes
+gist-memory talk --strategy <strategy_name> --message "What can you tell me based on the compressed context?"
 ```
 
-Additional functions such as decoding or summarising a prototype are
-available via the Python API.
-
-The local embedder loads the model from the Hugging Face cache only and will not
-attempt any network downloads. Ensure the embedding and chat models are
-pre-cached using the commands in the setup section or via `.codex/setup.sh`.
-
-Data is stored in the `brain` directory by default in the current working directory.
-
-## Scaling with Chroma
-
-If you exceed about **10k beliefs** or plan to run multi-process agents, switch to
-the Chroma backend:
-
-```yaml
-vector_store: chroma
-chroma_path: ./belief_db
-```
-
-Install the optional dependency first:
-
-```bash
-pip install "gist-memory[chroma]"
-```
-
-A quick benchmark shows brute-force JSON lookup taking ~20 ms for 1k beliefs
-versus <5 ms with Chroma. Larger datasets benefit even more.
-
-## Running Tests
-
-Install development dependencies and run `pytest`:
-
+### Running Tests (for contributors)
+Install development dependencies and run pytest:
 ```bash
 pip install -r requirements.txt
 pytest
 ```
 
-## Onboarding Demo
+### Onboarding Demo (Revised)
+The `examples/onboarding_demo.py` script will be updated to showcase the experimentation workflow. For example, it might:
 
-Code examples live under `examples/` while sample_data holds sample documents.
-A small onboarding demo shows the agent in action by ingesting short excerpts from the Apollo 11 moon landing transcripts and prints which prototypes were created or updated.
+1. Load a sample dataset.
+2. Apply two different example CompressionStrategy implementations.
+3. Feed the compressed output to a dummy LLM.
+4. Show results from a simple ValidationMetric.
 
-Run the demo after installing dependencies and pre-downloading the local
-embedding model:
-
+Run the demo (after setup):
 ```bash
-pip install -r requirements.txt
-# download the local model once
-gist-memory download-model --model-name all-MiniLM-L6-v2
-
-# run the example
 python examples/onboarding_demo.py
 ```
 
-The script loads all `*.txt` files from `sample_data/moon_landing`, stores them in a
-local database and displays the prototype assignments along with a final memory
-and prototype count.
+## Key Concepts
 
+* **CompressionStrategy:** An algorithm that takes input text and a token budget, and produces a compressed representation of that text suitable for an LLM prompt.
+* **ValidationMetric:** A method to evaluate the quality or utility of the compressed memory, often by assessing an LLM's performance on a task using that compressed memory.
+* **Experimentation Framework:** The tools and processes within Gist Memory for systematically running tests with different strategies, datasets, and metrics.
 
-## Segmentation Playbook
-
-See [docs/SEGMENTATION_PLAYBOOK.md](docs/SEGMENTATION_PLAYBOOK.md) for a detailed workflow on splitting long documents into belief-sized ideas before ingestion. The advanced `AgenticChunker` implements this strategy and can be used via `gist-memory init brain --chunker agentic` or programmatically with `agent.chunker = AgenticChunker()`.
-
-## Querying Playbook
-
-See [docs/QUERYING_PLAYBOOK.md](docs/QUERYING_PLAYBOOK.md) for tips on shaping search queries. It explains how to bias retrieval by embedding a templated version of a question when your notes follow a structured `WHO/WHAT/WHEN` format.
+For deeper insights into the concepts behind some of the example strategies (like Active Memory and Prototypes), refer to the Conceptual Guide (`AGENTS.md`).
 
 ## Architecture and Storage
 
-A high level overview of the modules and ingestion pipeline lives in
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).  The on-disk file layout is
-described in [docs/STORAGE_FORMAT.md](docs/STORAGE_FORMAT.md).
+The Gist Memory platform is designed for modularity. Core interfaces for compression and validation allow for diverse implementations.
+
+Persistent storage (like the JSON/NPY store) is primarily relevant for CompressionStrategy implementations that maintain a stateful long-term memory component (e.g., the prototype-based strategy). Other strategies might be stateless.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a high-level overview.
+

--- a/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
+++ b/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
@@ -1,0 +1,3 @@
+# Developing Compression Strategies
+
+Guidelines and examples for implementing new `CompressionStrategy` classes will be documented here.

--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -1,0 +1,3 @@
+# Developing Validation Metrics
+
+Guidelines for creating and registering new `ValidationMetric` implementations will be documented here.

--- a/docs/RUNNING_EXPERIMENTS.md
+++ b/docs/RUNNING_EXPERIMENTS.md
@@ -1,0 +1,3 @@
+# Running Experiments
+
+This document will describe how to configure and run experiments using the `gist-memory` CLI. Example configuration files and recommended workflows will be added in future updates.


### PR DESCRIPTION
## Summary
- overhaul README to present gist-memory as a platform for experimenting with memory compression
- add skeleton docs for running experiments and developing new strategies/metrics

## Testing
- `pytest -q`
- `pytest tests/test_cli.py::test_cli_stats -q`


------
https://chatgpt.com/codex/tasks/task_e_683c60420a008329994d9f6936ab33a5