### PR TITLE
Add generic experiment config and registry

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -62,7 +62,7 @@ _lazy_map = {
     "ConflictFlagger": "gist_memory.conflict_flagging",
     "ConflictLogger": "gist_memory.conflict_flagging",
     "SimpleConflictLogger": "gist_memory.conflict",
-    "ExperimentConfig": "gist_memory.experiment_runner",
+    "ExperimentConfig": "gist_memory.experiments.config",
     "run_experiment": "gist_memory.experiment_runner",
     "HistoryExperimentConfig": "gist_memory.history_experiment",
     "run_history_experiment": "gist_memory.history_experiment",

--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -458,6 +458,8 @@ class Agent:
         if llm is None:
             llm = LocalChatModel()
             self._chat_model = llm
+        if hasattr(llm, "load_model"):
+            llm.load_model()
 
         vec = embed_text([input_message])
         if vec.ndim != 1:

--- a/gist_memory/experiments/config.py
+++ b/gist_memory/experiments/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Shared dataclasses for experimentation framework."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+
+@dataclass(kw_only=True)
+class ExperimentConfig:
+    """Generic experiment configuration used across modules."""
+
+    dataset: Path | Sequence[Path] | Callable[[], Any]
+    similarity_threshold: float = 0.8
+    chunker: Any | None = None
+    summary_creator: Any | None = None
+    work_dir: Optional[Path] = None
+    active_memory_params: Dict[str, Any] | None = None
+    compression_strategy: Optional[str] = None
+    compression_params: Dict[str, Any] = field(default_factory=dict)
+    llm_model: Optional[str] = None
+    llm_api_key: Optional[str] = None
+    metrics: List[str] = field(default_factory=list)
+    metric_params: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+
+__all__ = ["ExperimentConfig"]

--- a/gist_memory/history_experiment.py
+++ b/gist_memory/history_experiment.py
@@ -4,23 +4,27 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Dict, Any
 
+from .experiments.config import ExperimentConfig
+
 import yaml
 
 from .active_memory_manager import ActiveMemoryManager, ConversationTurn
 from .embedding_pipeline import MockEncoder
 
 
-@dataclass
-class HistoryExperimentConfig:
+@dataclass(kw_only=True)
+class HistoryExperimentConfig(ExperimentConfig):
     """Configuration for :func:`run_history_experiment`."""
 
-    dataset: Path
     param_grid: List[Dict[str, Any]]
 
 
 # --------------------------------------------------------------
-def _load_dataset(path: Path) -> List[Dict[str, Any]]:
-    data = yaml.safe_load(path.read_text())
+def _load_dataset(source: Any) -> List[Dict[str, Any]]:
+    if callable(source):
+        data = source()
+    else:
+        data = yaml.safe_load(Path(source).read_text())
     return list(data)
 
 

--- a/gist_memory/registry.py
+++ b/gist_memory/registry.py
@@ -4,23 +4,8 @@ from __future__ import annotations
 
 from typing import Dict, Type
 
-
-class CompressionStrategy:
-    """Base interface for text compression strategies."""
-
-    id: str
-
-    def compress(self, text: str) -> str:  # pragma: no cover - interface
-        raise NotImplementedError
-
-
-class ValidationMetric:
-    """Base interface for evaluating predictions."""
-
-    id: str
-
-    def compute(self, reference: str, prediction: str) -> float:  # pragma: no cover
-        raise NotImplementedError
+from .compression import CompressionStrategy
+from .validation.metrics_abc import ValidationMetric
 
 
 _COMPRESSION_REGISTRY: Dict[str, Type[CompressionStrategy]] = {}

--- a/gist_memory/response_experiment.py
+++ b/gist_memory/response_experiment.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Dict, Any
 
+from .experiments.config import ExperimentConfig
+
 import tempfile
 import yaml
 
@@ -17,16 +19,18 @@ from .chunker import SentenceWindowChunker
 from .token_utils import token_count
 
 
-@dataclass
-class ResponseExperimentConfig:
+@dataclass(kw_only=True)
+class ResponseExperimentConfig(ExperimentConfig):
     """Configuration for :func:`run_response_experiment`."""
 
-    dataset: Path
     param_grid: List[Dict[str, Any]]
 
 
-def _load_dataset(path: Path) -> List[Dict[str, Any]]:
-    data = yaml.safe_load(path.read_text())
+def _load_dataset(source: Any) -> List[Dict[str, Any]]:
+    if callable(source):
+        data = source()
+    else:
+        data = yaml.safe_load(Path(source).read_text())
     return list(data)
 
 

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from gist_memory.experiment_runner import ExperimentConfig, run_experiment
+from gist_memory.experiments.config import ExperimentConfig
+from gist_memory.experiment_runner import run_experiment
 from gist_memory.active_memory_manager import ActiveMemoryManager
 from gist_memory.utils import load_agent
 from gist_memory.embedding_pipeline import MockEncoder


### PR DESCRIPTION
## Summary
- introduce `ExperimentConfig` dataclass for new experimentation framework
- expose plugin registry for compression strategies and validation metrics
- update modules and tests to use the new configuration
- ensure agent loads chat model lazily if available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c5f0d57108329a65b0bc5fd224466