### PR TITLE
Add CompressionTrace and update CompressionStrategy ABC

### DIFF
--- a/gist_memory/compression/__init__.py
+++ b/gist_memory/compression/__init__.py
@@ -1,5 +1,5 @@
 """Compression strategy interfaces and implementations."""
 
-from .strategies_abc import CompressedMemory, CompressionStrategy
+from .strategies_abc import CompressedMemory, CompressionStrategy, CompressionTrace
 
-__all__ = ["CompressedMemory", "CompressionStrategy"]
+__all__ = ["CompressedMemory", "CompressionStrategy", "CompressionTrace"]

--- a/gist_memory/compression/strategies_abc.py
+++ b/gist_memory/compression/strategies_abc.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Union, Any, Optional
+from typing import Dict, List, Union, Any, Optional, Tuple
+
+from .trace import CompressionTrace
 
 
 @dataclass
@@ -26,8 +28,12 @@ class CompressionStrategy(ABC):
         text_or_chunks: Union[str, List[str]],
         llm_token_budget: int,
         **kwargs: Any,
-    ) -> CompressedMemory:
-        """Return compressed form of ``text_or_chunks`` within ``llm_token_budget``."""
+    ) -> Tuple[CompressedMemory, CompressionTrace]:
+        """Return compressed form of ``text_or_chunks`` and trace.
+
+        The ``CompressedMemory`` holds the data to be given to an LLM while
+        ``CompressionTrace`` captures decision steps taken during compression.
+        """
 
 
-__all__ = ["CompressedMemory", "CompressionStrategy"]
+__all__ = ["CompressedMemory", "CompressionStrategy", "CompressionTrace"]

--- a/gist_memory/compression/trace.py
+++ b/gist_memory/compression/trace.py
@@ -1,0 +1,20 @@
+"""Data structures for tracking compression steps."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class CompressionTrace:
+    """Represents the chain-of-thought of a :class:`CompressionStrategy`."""
+
+    strategy_name: str
+    strategy_params: Dict[str, Any]
+    input_summary: Dict[str, Any]
+    steps: List[Dict[str, Any]] = field(default_factory=list)
+    output_summary: Dict[str, Any] = field(default_factory=dict)
+    final_compressed_object_preview: Optional[str] = None
+
+
+__all__ = ["CompressionTrace"]


### PR DESCRIPTION
## Summary
- extend compression strategy ABC to return a `CompressionTrace`
- implement new `CompressionTrace` dataclass
- update exports and example onboarding demo
- adjust tests for new interface

## Testing
- `pytest tests/test_compression_strategies.py -q`
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683c6b012b388329a1fdc76616e30a00