### PR TITLE
Fix lazy imports

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -69,7 +69,6 @@ _lazy_map = {
     "run_experiment": "gist_memory.experiment_runner",
     "HistoryExperimentConfig": "gist_memory.history_experiment",
     "run_history_experiment": "gist_memory.history_experiment",
-    "negation_conflict": "gist_memory.conflict",
     "negation_conflict": "gist_memory.prototype.conflict",
     "load_agent": "gist_memory.utils",
     "tokenize_text": "gist_memory.token_utils",

--- a/gist_memory/prototype/conflict.py
+++ b/gist_memory/prototype/conflict.py
@@ -6,7 +6,7 @@ import json
 import re
 from pathlib import Path
 
-from .models import RawMemory
+from ..models import RawMemory
 
 
 # naive regex for "X is Y" / "X is not Y" style statements


### PR DESCRIPTION
## Summary
- fix RawMemory import in prototype conflict helpers
- fix duplicate negation_conflict entry in lazy loader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683c731cbca4832998568f801f3568fd