### PR TITLE
Update setup to remove gist_memory dependency

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -20,7 +20,16 @@ pip3 install --no-cache-dir flake8 pytest
 pip3 install --no-cache-dir rich typer portalocker
 
 # Pre-download the default local embedding model so it is available offline
-#python3 -m gist_memory download-model --model-name all-MiniLM-L6-v2
+python3 - <<'EOF'
+from sentence_transformers import SentenceTransformer
+
+SentenceTransformer("all-MiniLM-L6-v2")
+EOF
 # Pre-download the default chat model for talk mode
-#python3 -m gist_memory download-chat-model --model-name distilgpt2
+python3 - <<'EOF'
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+AutoTokenizer.from_pretrained("distilgpt2")
+AutoModelForCausalLM.from_pretrained("distilgpt2")
+EOF
 


### PR DESCRIPTION
## Summary
- simplify setup to avoid requiring gist_memory CLI
- directly download default embedding and chat models using Python

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gist_memory.prototype.models')*
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_683c7785e380832998640fbb1f200faa