### PR TITLE
Fix conflict import and sync metadata

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -108,6 +108,7 @@ class Agent:
         if not isinstance(value, Chunker):
             raise TypeError("chunker must implement Chunker interface")
         self.prototype_system.chunker = value
+        self.store.meta["chunker"] = getattr(value, "id", type(value).__name__)
 
     # ------------------------------------------------------------------
     @property
@@ -117,6 +118,7 @@ class Agent:
     @similarity_threshold.setter
     def similarity_threshold(self, value: float) -> None:
         self.prototype_system.similarity_threshold = value
+        self.store.meta["tau"] = float(value)
 
     # ------------------------------------------------------------------
     @property

--- a/gist_memory/prototype/conflict_flagging.py
+++ b/gist_memory/prototype/conflict_flagging.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import numpy as np
 
-from .models import RawMemory
+from ..models import RawMemory
 
 
 _NEG_WORDS = {"not", "no", "never", "n't"}

--- a/gist_memory/prototype_system_strategy.py
+++ b/gist_memory/prototype_system_strategy.py
@@ -12,7 +12,6 @@ from typing import Callable, Dict, List, Optional
 import numpy as np
 
 from .chunker import Chunker, SentenceWindowChunker
-from .embedding_pipeline import embed_text
 from .json_npy_store import JsonNpyVectorStore, BeliefPrototype, RawMemory
 from .memory_creation import ExtractiveSummaryCreator, MemoryCreator
 from .prototype.canonical import render_five_w_template
@@ -126,7 +125,8 @@ class PrototypeSystemStrategy(CompressionStrategy):
             render_five_w_template(c, who=who, what=what, when=when, where=where, why=why)
             for c in chunks
         ]
-        vecs = embed_text(canonical)
+        from . import agent as _agent
+        vecs = _agent.embed_text(canonical)
         if vecs.ndim == 1:
             vecs = vecs.reshape(1, -1)
 
@@ -218,7 +218,8 @@ class PrototypeSystemStrategy(CompressionStrategy):
     ) -> Dict[str, object]:
         """Return nearest prototypes and memories for ``text``."""
 
-        vec = embed_text(text)
+        from . import agent as _agent
+        vec = _agent.embed_text(text)
         if vec.ndim != 1:
             vec = vec.reshape(-1)
         nearest = self.store.find_nearest(vec, k=top_k_prototypes)


### PR DESCRIPTION
## Summary
- fix module import path for conflict flagging
- keep store metadata in sync when changing chunker or tau
- use patched embed function in prototype system to enable tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c7a90d3788329adecf472552aec14