### PR TITLE
Add LLM provider auth via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,16 @@ This project requires **Python 3.11+**.
     ```
     To run completely offline after downloads, set:
     ```
-    export HF_HUB_OFFLINE=1
-    export TRANSFORMERS_OFFLINE=1
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+```
+
+3.  **Set API Keys for Cloud Providers:**
+    If you plan to use OpenAI or Gemini models, export your credentials as
+    environment variables before running the CLI:
+    ```bash
+    export OPENAI_API_KEY="sk-..."
+    export GEMINI_API_KEY="..."
     ```
 
 Alternatively, install the package from source:

--- a/gist_memory/llm_providers/__init__.py
+++ b/gist_memory/llm_providers/__init__.py
@@ -1,0 +1,7 @@
+"""LLM provider implementations."""
+
+from .openai_provider import OpenAIProvider
+from .gemini_provider import GeminiProvider
+from .local_provider import LocalTransformersProvider
+
+__all__ = ["OpenAIProvider", "GeminiProvider", "LocalTransformersProvider"]

--- a/gist_memory/llm_providers/gemini_provider.py
+++ b/gist_memory/llm_providers/gemini_provider.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import os
+
+import google.generativeai as genai
+
+from ..llm_providers_abc import LLMProvider
+
+
+class GeminiProvider(LLMProvider):
+    """LLMProvider implementation for Google Gemini."""
+
+    MODEL_TOKEN_LIMITS: Dict[str, int] = {
+        "gemini-1.5-pro-latest": 1_048_576,
+    }
+
+    def get_token_budget(self, model_name: str, **kwargs) -> int:
+        default = kwargs.get("default", 8192)
+        return self.MODEL_TOKEN_LIMITS.get(model_name, default)
+
+    def count_tokens(self, text: str, model_name: str, **kwargs) -> int:
+        model = genai.GenerativeModel(model_name)
+        return model.count_tokens(text).total_tokens
+
+    def generate_response(
+        self,
+        prompt: str,
+        model_name: str,
+        max_new_tokens: int,
+        **llm_kwargs: Any,
+    ) -> str:
+        api_key = llm_kwargs.pop("api_key", None)
+        if api_key is None:
+            api_key = os.getenv("GEMINI_API_KEY")
+        if api_key:
+            genai.configure(api_key=api_key)
+        model = genai.GenerativeModel(model_name)
+        resp = model.generate_content(
+            prompt, generation_config={"max_output_tokens": max_new_tokens}
+        )
+        return resp.text.strip()

--- a/gist_memory/llm_providers/local_provider.py
+++ b/gist_memory/llm_providers/local_provider.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..llm_providers_abc import LLMProvider
+from ..local_llm import LocalChatModel
+from ..token_utils import token_count
+
+
+class LocalTransformersProvider(LLMProvider):
+    """LLMProvider using local Hugging Face models."""
+
+    def __init__(self) -> None:
+        self._models: Dict[str, LocalChatModel] = {}
+
+    def _get_model(self, model_name: str, max_new_tokens: int) -> LocalChatModel:
+        model = self._models.get(model_name)
+        if model is None:
+            model = LocalChatModel(
+                model_name=model_name,
+                max_new_tokens=max_new_tokens,
+            )
+            self._models[model_name] = model
+        elif model.max_new_tokens != max_new_tokens:
+            model.max_new_tokens = max_new_tokens
+        return model
+
+    def get_token_budget(self, model_name: str, **kwargs) -> int:
+        model = self._get_model(
+            model_name,
+            kwargs.get("max_new_tokens", 100),
+        )
+        with model.loaded():
+            return model._context_length()
+
+    def count_tokens(self, text: str, model_name: str, **kwargs) -> int:
+        model = self._get_model(
+            model_name,
+            kwargs.get("max_new_tokens", 100),
+        )
+        with model.loaded():
+            return token_count(model.tokenizer, text)
+
+    def generate_response(
+        self,
+        prompt: str,
+        model_name: str,
+        max_new_tokens: int,
+        **llm_kwargs: Any,
+    ) -> str:
+        model = self._get_model(model_name, max_new_tokens)
+        with model.loaded():
+            model.max_new_tokens = max_new_tokens
+            return model.reply(prompt)

--- a/gist_memory/llm_providers/openai_provider.py
+++ b/gist_memory/llm_providers/openai_provider.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import os
+
+import openai
+import tiktoken
+
+from ..llm_providers_abc import LLMProvider
+
+
+class OpenAIProvider(LLMProvider):
+    """LLMProvider implementation for the OpenAI API."""
+
+    # Basic, easily extensible registry of known model context sizes
+    MODEL_TOKEN_LIMITS: Dict[str, int] = {
+        "gpt-3.5-turbo": 4096,
+        "gpt-4-turbo": 128000,
+    }
+
+    def get_token_budget(self, model_name: str, **kwargs) -> int:
+        default = kwargs.get("default", 4096)
+        return self.MODEL_TOKEN_LIMITS.get(model_name, default)
+
+    def count_tokens(self, text: str, model_name: str, **kwargs) -> int:
+        try:
+            enc = tiktoken.encoding_for_model(model_name)
+        except Exception:
+            enc = tiktoken.get_encoding("gpt2")
+        return len(enc.encode(text))
+
+    def generate_response(
+        self,
+        prompt: str,
+        model_name: str,
+        max_new_tokens: int,
+        **llm_kwargs: Any,
+    ) -> str:
+        api_key = llm_kwargs.pop("api_key", None)
+        if api_key is None:
+            api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            openai.api_key = api_key
+        messages = [{"role": "user", "content": prompt}]
+        resp = openai.ChatCompletion.create(
+            model=model_name,
+            messages=messages,
+            max_tokens=max_new_tokens,
+            **llm_kwargs,
+        )
+        return resp.choices[0].message["content"].strip()

--- a/gist_memory/llm_providers_abc.py
+++ b/gist_memory/llm_providers_abc.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Abstract base class for Large Language Model providers."""
+
+from abc import ABC, abstractmethod
+
+
+class LLMProvider(ABC):
+    """Interface for LLM provider implementations."""
+
+    @abstractmethod
+    def get_token_budget(self, model_name: str, **kwargs) -> int:
+        """Return maximum context window (in tokens) for ``model_name``."""
+
+    @abstractmethod
+    def count_tokens(self, text: str, model_name: str, **kwargs) -> int:
+        """Return token count for ``text`` using ``model_name`` tokenizer."""
+
+    @abstractmethod
+    def generate_response(
+        self,
+        prompt: str,
+        model_name: str,
+        max_new_tokens: int,
+        **llm_kwargs,
+    ) -> str:
+        """Generate a text completion from ``prompt``."""

--- a/llm_models_config.yaml
+++ b/llm_models_config.yaml
@@ -1,0 +1,23 @@
+# Mapping of model ids to provider configuration
+
+# Example defaults - extend as needed
+
+gpt-4-turbo:
+  provider: openai
+  model_name: gpt-4-turbo
+  token_budget: 128000
+
+gpt-3.5-turbo:
+  provider: openai
+  model_name: gpt-3.5-turbo
+  token_budget: 4096
+
+gemini-1.5-pro-latest:
+  provider: gemini
+  model_name: gemini-1.5-pro-latest
+  token_budget: 1048576
+
+distilgpt2:
+  provider: local
+  model_name: distilgpt2
+  token_budget: 1024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "typer[all]",
     "portalocker",
     "rich>=13.6",
+    "google-generativeai",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ rich>=13.6
 spacy
 typer[all]
 portalocker
+google-generativeai


### PR DESCRIPTION
## Summary
- add instructions for OpenAI/Gemini API keys in README
- support API keys via environment variables in provider classes
- tidy local provider formatting and line length
- fix dependency names in requirements.txt

## Testing
- `flake8 --max-line-length=120 --extend-ignore=E203 gist_memory/llm_providers/openai_provider.py gist_memory/llm_providers/gemini_provider.py gist_memory/llm_providers/local_provider.py gist_memory/llm_providers_abc.py gist_memory/local_llm.py tests/test_local_llm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c8133437c8329a42b063a95003508