### PR TITLE
Implement pluggable validation metric system

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It provides a framework to implement and compare different approaches to making 
     * Active memory management (inspired by human working memory).
     * Gist-based prototype systems for long-term knowledge consolidation.
     * Extractive summarization, and more.
-* **Pluggable `ValidationMetric` Interface:** Define and apply custom metrics to evaluate the effectiveness of compressed memory in LLM interactions (e.g., information recall, F1 score, coherence).
+* **Pluggable `ValidationMetric` Interface:** Define and apply custom metrics to evaluate the effectiveness of compressed memory in LLM interactions (e.g., information recall, ROUGE, BLEU). Metrics can leverage the Hugging Face `evaluate` library.
 * **Command-Line Interface (CLI):** Manage experiments, test strategies, and interact with the system.
 * **Local LLM Interaction:** Test compressed memory with local LLMs for end-to-end validation.
 * **Flexible Storage Backend:** Includes a lightweight JSON/NPY backend for components of strategies that require persistence (like LTM prototypes). (ChromaDB support can be mentioned if it remains relevant for specific strategies).

--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -1,3 +1,43 @@
 # Developing Validation Metrics
 
-Guidelines for creating and registering new `ValidationMetric` implementations will be documented here.
+Validation metrics assess how well an LLM performs when using compressed memory.
+All metrics must subclass `ValidationMetric` and register themselves with the
+registry so experiment configurations can reference them.
+
+## ValidationMetric ABC
+
+```python
+from gist_memory.validation.metrics_abc import ValidationMetric
+
+class MyMetric(ValidationMetric):
+    metric_id = "my_metric"
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs):
+        ...  # return {"score_name": value}
+```
+
+Use `register_validation_metric` to make the metric discoverable:
+
+```python
+from gist_memory.registry import register_validation_metric
+
+register_validation_metric(MyMetric.metric_id, MyMetric)
+```
+
+## Hugging Face evaluate Metrics
+
+Metrics backed by the [`evaluate`](https://github.com/huggingface/evaluate)
+library can extend `HFValidationMetric` which handles loading the metric:
+
+```python
+from gist_memory.validation.hf_metrics import HFValidationMetric
+
+class RougeMetric(HFValidationMetric):
+    metric_id = "rouge_hf"
+
+    def __init__(self, **params):
+        super().__init__("rouge", **params)
+```
+
+When running experiments, metrics are selected by `metric_id` and optional
+initialisation parameters.

--- a/docs/RUNNING_EXPERIMENTS.md
+++ b/docs/RUNNING_EXPERIMENTS.md
@@ -1,3 +1,19 @@
 # Running Experiments
 
-This document will describe how to configure and run experiments using the `gist-memory` CLI. Example configuration files and recommended workflows will be added in future updates.
+Experiments are configured with `ExperimentConfig` or `ResponseExperimentConfig`.
+Validation metrics are listed in the `validation_metrics` field:
+
+```python
+cfg = ResponseExperimentConfig(
+    dataset=Path("dialogues.yaml"),
+    param_grid=[{"config_prompt_num_forced_recent_turns": 1}],
+    validation_metrics=[
+        {"id": "rouge_hf", "params": {"rouge_types": ["rouge1"]}},
+        {"id": "exact_match", "params": {}},
+    ],
+)
+```
+
+During the run each metric is instantiated and its scores averaged across the
+dataset. Results are returned as a list of dictionaries containing the parameter
+set and metric scores.

--- a/gist_memory/experiments/config.py
+++ b/gist_memory/experiments/config.py
@@ -35,8 +35,7 @@ class ExperimentConfig:
     llm_api_key: Optional[str] = None
 
     # Validation metrics to compute and their individual configs
-    metrics: List[str] = field(default_factory=list)
-    metric_params: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    validation_metrics: List[Dict[str, Any]] = field(default_factory=list)
 
     # Optional experiment specific settings from legacy experiments
     work_dir: Optional[Path] = None

--- a/gist_memory/registry.py
+++ b/gist_memory/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Plugin registries for compression strategies and validation metrics."""
 
-from typing import Dict, Type
+from typing import Any, Dict, Type
 
 
 class CompressionStrategy:
@@ -19,12 +19,17 @@ class ValidationMetric:
 
     id: str
 
-    def compute(self, reference: str, prediction: str) -> float:  # pragma: no cover
+    def evaluate(
+        self,
+        llm_response: str,
+        reference_answer: str,
+        **kwargs: Any,
+    ) -> Dict[str, float]:  # pragma: no cover - interface
         raise NotImplementedError
 
 
 _COMPRESSION_REGISTRY: Dict[str, Type[CompressionStrategy]] = {}
-_VALIDATION_REGISTRY: Dict[str, Type[ValidationMetric]] = {}
+_VALIDATION_METRIC_REGISTRY: Dict[str, Type[ValidationMetric]] = {}
 
 
 def register_compression_strategy(id: str, strategy_class: Type[CompressionStrategy]) -> None:
@@ -36,7 +41,13 @@ def register_compression_strategy(id: str, strategy_class: Type[CompressionStrat
 def register_validation_metric(id: str, metric_class: Type[ValidationMetric]) -> None:
     """Register ``metric_class`` under ``id``."""
 
-    _VALIDATION_REGISTRY[id] = metric_class
+    _VALIDATION_METRIC_REGISTRY[id] = metric_class
+
+
+def get_validation_metric_class(id: str) -> Type[ValidationMetric]:
+    """Return the metric class registered under ``id``."""
+
+    return _VALIDATION_METRIC_REGISTRY[id]
 
 
 __all__ = [
@@ -44,6 +55,7 @@ __all__ = [
     "ValidationMetric",
     "register_compression_strategy",
     "register_validation_metric",
+    "get_validation_metric_class",
     "_COMPRESSION_REGISTRY",
-    "_VALIDATION_REGISTRY",
+    "_VALIDATION_METRIC_REGISTRY",
 ]

--- a/gist_memory/validation/__init__.py
+++ b/gist_memory/validation/__init__.py
@@ -1,0 +1,19 @@
+from .metrics_abc import ValidationMetric
+from .hf_metrics import (
+    HFValidationMetric,
+    RougeHFMetric,
+    BleuHFMetric,
+    MeteorHFMetric,
+    BertScoreHFMetric,
+    ExactMatchMetric,
+)
+
+__all__ = [
+    "ValidationMetric",
+    "HFValidationMetric",
+    "RougeHFMetric",
+    "BleuHFMetric",
+    "MeteorHFMetric",
+    "BertScoreHFMetric",
+    "ExactMatchMetric",
+]

--- a/gist_memory/validation/hf_metrics.py
+++ b/gist_memory/validation/hf_metrics.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Validation metrics implemented with the Hugging Face ``evaluate`` package."""
+
+from typing import Any, Dict
+
+import evaluate  # type: ignore
+
+from .metrics_abc import ValidationMetric
+from ..registry import register_validation_metric
+
+
+class HFValidationMetric(ValidationMetric):
+    """Base class for metrics that rely on ``evaluate``."""
+
+    def __init__(self, hf_metric_name: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.hf_metric_name = hf_metric_name
+        try:
+            load_args = self.config_params.get("load_args", {})
+            self.metric_loader = evaluate.load(self.hf_metric_name, **load_args)
+        except Exception as exc:  # pragma: no cover - passthrough
+            raise ValueError(
+                f"Could not load Hugging Face metric '{self.hf_metric_name}': {exc}"
+            )
+
+
+class RougeHFMetric(HFValidationMetric):
+    metric_id = "rouge_hf"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__("rouge", **kwargs)
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs: Any) -> Dict[str, float]:
+        compute_args = {}
+        for key in ["rouge_types", "use_stemmer", "newline_sep"]:
+            if key in self.config_params:
+                compute_args[key] = self.config_params[key]
+        return self.metric_loader.compute(
+            predictions=[llm_response], references=[reference_answer], **compute_args
+        )
+
+
+class BleuHFMetric(HFValidationMetric):
+    metric_id = "bleu_hf"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__("bleu", **kwargs)
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs: Any) -> Dict[str, float]:
+        compute_args = {}
+        if "max_order" in self.config_params:
+            compute_args["max_order"] = self.config_params["max_order"]
+        return self.metric_loader.compute(
+            predictions=[llm_response], references=[reference_answer], **compute_args
+        )
+
+
+class MeteorHFMetric(HFValidationMetric):
+    metric_id = "meteor_hf"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__("meteor", **kwargs)
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs: Any) -> Dict[str, float]:
+        return self.metric_loader.compute(predictions=[llm_response], references=[reference_answer])
+
+
+class BertScoreHFMetric(HFValidationMetric):
+    metric_id = "bertscore_hf"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__("bertscore", **kwargs)
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs: Any) -> Dict[str, float]:
+        compute_args = {}
+        for key in ["lang", "model_type"]:
+            if key in self.config_params:
+                compute_args[key] = self.config_params[key]
+        return self.metric_loader.compute(
+            predictions=[llm_response], references=[reference_answer], **compute_args
+        )
+
+
+class ExactMatchMetric(ValidationMetric):
+    metric_id = "exact_match"
+
+    def evaluate(self, llm_response: str, reference_answer: str, **kwargs: Any) -> Dict[str, float]:
+        match = float(llm_response.strip() == reference_answer.strip())
+        return {"exact_match": match}
+
+
+# Register metrics
+register_validation_metric(RougeHFMetric.metric_id, RougeHFMetric)
+register_validation_metric(BleuHFMetric.metric_id, BleuHFMetric)
+register_validation_metric(MeteorHFMetric.metric_id, MeteorHFMetric)
+register_validation_metric(BertScoreHFMetric.metric_id, BertScoreHFMetric)
+register_validation_metric(ExactMatchMetric.metric_id, ExactMatchMetric)
+
+__all__ = [
+    "HFValidationMetric",
+    "RougeHFMetric",
+    "BleuHFMetric",
+    "MeteorHFMetric",
+    "BertScoreHFMetric",
+    "ExactMatchMetric",
+]

--- a/gist_memory/validation/metrics_abc.py
+++ b/gist_memory/validation/metrics_abc.py
@@ -3,24 +3,35 @@ from __future__ import annotations
 """Abstract base class for validation metrics."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from ..memory_creation import CompressedMemoryObject
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints only
+    from ..compression.strategies_abc import CompressedMemory
+    from ..compression.trace import CompressionTrace
 else:  # pragma: no cover - avoid runtime dependency
-    CompressedMemoryObject = Any
+    CompressedMemory = Any
+    CompressionTrace = Any
 
 
 class ValidationMetric(ABC):
     """Interface for evaluating compression strategies and LLM responses."""
 
+    metric_id: str
+
+    def __init__(self, **kwargs: Any) -> None:  # pragma: no cover - simple init
+        """Store metric-specific configuration parameters."""
+        self.config_params = kwargs
+
     @abstractmethod
     def evaluate(
         self,
-        original_query: str,
         llm_response: str,
-        compressed_context: CompressedMemoryObject,
-        reference_data: Any,
+        reference_answer: str,
+        original_query: Optional[str] = None,
+        compressed_context: Optional[CompressedMemory] = None,
+        compression_trace: Optional[CompressionTrace] = None,
+        llm_provider_info: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, float]:
         """Return metric results as a dictionary."""
+        

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "portalocker",
     "rich>=13.6",
     "google-generativeai",
+    "evaluate",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ spacy
 typer[all]
 portalocker
 google-generativeai
+evaluate

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,8 +3,9 @@ from gist_memory.registry import (
     ValidationMetric,
     register_compression_strategy,
     register_validation_metric,
+    get_validation_metric_class,
     _COMPRESSION_REGISTRY,
-    _VALIDATION_REGISTRY,
+    _VALIDATION_METRIC_REGISTRY,
 )
 
 
@@ -23,8 +24,9 @@ def test_register_validation_metric():
     class DummyMetric(ValidationMetric):
         id = "metric"
 
-        def compute(self, reference: str, prediction: str) -> float:
-            return 0.0
+        def evaluate(self, llm_response: str, reference_answer: str, **kw):
+            return {"score": 0.0}
 
     register_validation_metric(DummyMetric.id, DummyMetric)
-    assert _VALIDATION_REGISTRY["metric"] is DummyMetric
+    assert _VALIDATION_METRIC_REGISTRY["metric"] is DummyMetric
+    assert get_validation_metric_class("metric") is DummyMetric

--- a/tests/test_response_experiment.py
+++ b/tests/test_response_experiment.py
@@ -38,8 +38,14 @@ def test_response_experiment_runs(monkeypatch, tmp_path):
     monkeypatch.setattr("gist_memory.local_llm.LocalChatModel", DummyLLM)
 
     params = [{"config_prompt_num_forced_recent_turns": 1}]
-    cfg = ResponseExperimentConfig(dataset=data, param_grid=params)
+    cfg = ResponseExperimentConfig(
+        dataset=data,
+        param_grid=params,
+        validation_metrics=[{"id": "exact_match", "params": {}}],
+    )
     results = run_response_experiment(cfg)
     assert len(results) == 1
     res = results[0]
-    assert "avg_f1" in res and "avg_prompt_tokens" in res
+    assert res["metrics"]["exact_match"]["exact_match"] == 1.0
+    assert "avg_prompt_tokens" in res
+

--- a/tests/test_validation_metrics.py
+++ b/tests/test_validation_metrics.py
@@ -1,0 +1,61 @@
+import sys
+import types
+import pytest
+
+# Provide a lightweight stub for the optional ``evaluate`` dependency
+evaluate_stub = types.SimpleNamespace(load=lambda *a, **k: None)
+sys.modules.setdefault("evaluate", evaluate_stub)
+
+from gist_memory.validation.hf_metrics import (
+    RougeHFMetric,
+    BleuHFMetric,
+    MeteorHFMetric,
+    BertScoreHFMetric,
+    ExactMatchMetric,
+    HFValidationMetric,
+)
+from gist_memory.registry import get_validation_metric_class
+
+
+def test_exact_match_metric():
+    metric = ExactMatchMetric()
+    scores = metric.evaluate("hi", "hi")
+    assert scores["exact_match"] == 1.0
+    scores = metric.evaluate("hi", "bye")
+    assert scores["exact_match"] == 0.0
+
+
+def test_metric_registration_lookup():
+    cls = get_validation_metric_class("exact_match")
+    assert cls is ExactMatchMetric
+
+
+def test_hf_metrics(monkeypatch):
+    def fake_load(name, **kwargs):
+        class FakeMetric:
+            def compute(self, predictions, references, **kw):
+                return {"score": len(predictions[0]) + len(references[0])}
+
+        fake_load.called = name
+        return FakeMetric()
+
+    monkeypatch.setattr("evaluate.load", fake_load)
+
+    metric = RougeHFMetric()
+    scores = metric.evaluate("a", "b")
+    assert scores["score"] == 2
+    assert fake_load.called == "rouge"
+
+    metric = BleuHFMetric()
+    metric.evaluate("a", "b")
+    assert fake_load.called == "bleu"
+
+    metric = MeteorHFMetric()
+    metric.evaluate("a", "b")
+    assert fake_load.called == "meteor"
+
+    metric = BertScoreHFMetric()
+    metric.evaluate("a", "b")
+    assert fake_load.called == "bertscore"
+
+


### PR DESCRIPTION
## Summary
- add `evaluate` dependency
- define `ValidationMetric` ABC and HF-backed metrics
- add metric registry and registration for metrics
- support metrics in `ResponseExperiment`
- document metric development and usage
- test metric registration, HF metrics and experiment integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c898324788329929dae059e0fe531