### PR TITLE
Implement strategy package tooling

### DIFF
--- a/docs/SHARING_STRATEGIES.md
+++ b/docs/SHARING_STRATEGIES.md
@@ -1,0 +1,40 @@
+# Sharing Compression Strategies
+
+This document describes the experimental "strategy package" format.
+
+A package is a directory containing a `strategy_package.yaml` manifest, the
+strategy implementation, optional experiment configurations and supporting
+files. Packages make it easier to share and run custom strategies.
+
+```
+my_strategy/
+    strategy.py                 # implementation
+    strategy_package.yaml       # manifest
+    requirements.txt            # optional dependencies
+    README.md                   # description
+    experiments/
+        example.yaml            # optional experiment config
+```
+
+The manifest has a few required fields:
+
+```yaml
+package_format_version: "1.0"
+strategy_id: my-strategy
+strategy_class_name: MyStrategy
+strategy_module: strategy
+display_name: My Strategy
+version: "0.1.0"
+authors:
+  - You
+description: Short description.
+```
+
+Use `gist-memory package create` to generate a template. Validate your package
+with `gist-memory package validate <path>`.
+
+Run an experiment from a package with:
+
+```
+gist-memory experiment run-package /path/to/package --experiment experiments/example.yaml
+```

--- a/examples/sample_strategy_package/README.md
+++ b/examples/sample_strategy_package/README.md
@@ -1,0 +1,1 @@
+# Sample Strategy Package

--- a/examples/sample_strategy_package/experiments/example.yaml
+++ b/examples/sample_strategy_package/experiments/example.yaml
@@ -1,0 +1,5 @@
+dataset: ../../tests/data/response_dialogues.yaml
+param_grid:
+  - {config_prompt_num_forced_recent_turns: 1}
+packaged_strategy_config:
+  strategy_params: {}

--- a/examples/sample_strategy_package/strategy.py
+++ b/examples/sample_strategy_package/strategy.py
@@ -1,0 +1,15 @@
+from gist_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+
+class SampleStrategy(CompressionStrategy):
+    """Trivial example strategy that returns the input unchanged."""
+
+    id = "sample"
+
+    def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+        text = text_or_chunks if isinstance(text_or_chunks, str) else " ".join(text_or_chunks)
+        return CompressedMemory(text=text), CompressionTrace()

--- a/examples/sample_strategy_package/strategy_package.yaml
+++ b/examples/sample_strategy_package/strategy_package.yaml
@@ -1,0 +1,9 @@
+package_format_version: "1.0"
+strategy_id: sample
+strategy_class_name: SampleStrategy
+strategy_module: strategy
+display_name: Sample Strategy
+version: "0.1.0"
+authors:
+  - Example Author
+description: Example packaged strategy.

--- a/gist_memory/package_utils.py
+++ b/gist_memory/package_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Utilities for working with strategy packages."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+from .compression.strategies_abc import CompressionStrategy
+
+
+REQUIRED_FIELDS = {
+    "package_format_version",
+    "strategy_id",
+    "strategy_class_name",
+    "strategy_module",
+    "display_name",
+    "version",
+    "authors",
+    "description",
+}
+
+
+def load_manifest(path: Path) -> Dict[str, Any]:
+    import yaml
+
+    data = yaml.safe_load(path.read_text())
+    return dict(data or {})
+
+
+def validate_manifest(manifest: Dict[str, Any]) -> list[str]:
+    errors = []
+    for field in REQUIRED_FIELDS:
+        if field not in manifest:
+            errors.append(f"Missing required field: {field}")
+    return errors
+
+
+def import_module_from_path(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_strategy_class(package_dir: Path, manifest: Dict[str, Any]) -> type[CompressionStrategy]:
+    module_name = manifest["strategy_module"]
+    class_name = manifest["strategy_class_name"]
+    module_path = package_dir / f"{module_name}.py"
+    module = import_module_from_path(module_name, module_path)
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        raise ImportError(f"Class {class_name} not found in {module_name}")
+    if not issubclass(cls, CompressionStrategy):
+        raise TypeError(f"{class_name} is not a CompressionStrategy")
+    return cls
+
+__all__ = [
+    "load_manifest",
+    "validate_manifest",
+    "import_module_from_path",
+    "load_strategy_class",
+]


### PR DESCRIPTION
## Summary
- add utilities for parsing and importing strategy packages
- extend `run_response_experiment` to accept a strategy instance
- expose CLI `package` and `experiment run-package` commands
- document sharing strategies and provide an example package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cabb8c938832984de67a1ca589b5d