### PR TITLE
Support dynamic strategy packages

### DIFF
--- a/gist_memory/experiment_runner.py
+++ b/gist_memory/experiment_runner.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Any
 
+from .compression.strategies_abc import CompressionStrategy
+
 from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
 from .active_memory_manager import ActiveMemoryManager
@@ -15,7 +17,10 @@ from .experiments.config import ExperimentConfig
 from .embedding_pipeline import embed_text, get_embedding_dim
 
 
-def run_experiment(config: ExperimentConfig) -> Dict[str, Any]:
+def run_experiment(
+    config: ExperimentConfig,
+    strategy: CompressionStrategy | None = None,
+) -> Dict[str, Any]:
     """Ingest ``config.dataset`` and return metrics."""
 
     work = config.work_dir or Path(tempfile.mkdtemp())

--- a/gist_memory/history_experiment.py
+++ b/gist_memory/history_experiment.py
@@ -8,6 +8,7 @@ import yaml
 
 from .active_memory_manager import ActiveMemoryManager, ConversationTurn
 from .embedding_pipeline import MockEncoder
+from .compression.strategies_abc import CompressionStrategy
 
 
 @dataclass
@@ -47,7 +48,10 @@ def _evaluate_dialogue(sample: Dict[str, Any], params: Dict[str, Any], encoder: 
 
 
 # --------------------------------------------------------------
-def run_history_experiment(config: HistoryExperimentConfig) -> List[Dict[str, Any]]:
+def run_history_experiment(
+    config: HistoryExperimentConfig,
+    strategy: CompressionStrategy | None = None,
+) -> List[Dict[str, Any]]:
     """Run history parameter tuning experiment on ``config.dataset``."""
 
     dataset = _load_dataset(config.dataset)

--- a/gist_memory/response_experiment.py
+++ b/gist_memory/response_experiment.py
@@ -15,6 +15,7 @@ from .json_npy_store import JsonNpyVectorStore
 from .embedding_pipeline import MockEncoder
 from .chunker import SentenceWindowChunker
 from .registry import get_validation_metric_class
+from . import validation  # ensure metrics are registered
 from .compression.strategies_abc import CompressionStrategy
 
 


### PR DESCRIPTION
## Summary
- allow experiment runner and history experiment to accept a strategy instance
- add dynamic loader `load_strategy_class_from_module` for package strategies
- ensure response experiments auto-register metrics

## Testing
- `pytest -q tests/test_experiment_runner.py tests/test_response_experiment.py tests/test_history_experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_683ce9f99480832998a81d33d57ba186