### PR TITLE
Improve compression tests

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -8,16 +8,35 @@ from gist_memory.registry import (
     _VALIDATION_METRIC_REGISTRY,
 )
 
+from gist_memory.compression.strategies_abc import (
+    CompressedMemory,
+    CompressionTrace,
+)
+
 
 def test_register_compression_strategy():
     class DummyStrategy(CompressionStrategy):
         id = "dummy"
 
-        def compress(self, text: str) -> str:
-            return text
+        def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+            if isinstance(text_or_chunks, list):
+                text = " ".join(text_or_chunks)
+            else:
+                text = text_or_chunks
+            text = text[:llm_token_budget] if llm_token_budget else text
+            compressed = CompressedMemory(text=text)
+            trace = CompressionTrace(
+                strategy_name=self.id,
+                strategy_params={"llm_token_budget": llm_token_budget},
+                input_summary={"input_length": len(text_or_chunks if isinstance(text_or_chunks, str) else " ".join(text_or_chunks))},
+            )
+            return compressed, trace
 
     register_compression_strategy(DummyStrategy.id, DummyStrategy)
     assert _COMPRESSION_REGISTRY["dummy"] is DummyStrategy
+    compressed, trace = DummyStrategy().compress("alpha bravo", llm_token_budget=5)
+    assert isinstance(compressed, CompressedMemory)
+    assert isinstance(trace, CompressionTrace)
 
 
 def test_register_validation_metric():


### PR DESCRIPTION
## Summary
- expand compression strategy tests for built‑ins
- verify registry uses the new compression interface

## Testing
- `pytest -k 'compression' -q`

------
https://chatgpt.com/codex/tasks/task_e_683d18e94bac8329878baac3d2b2bf8f