### PR TITLE
Ensure embedding model loads offline

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -27,7 +27,10 @@ pip3 install --no-cache-dir rich typer portalocker
 python3 - <<'PY'
 from sentence_transformers import SentenceTransformer
 
-SentenceTransformer("all-MiniLM-L6-v2")
+# Use the fully qualified model name to ensure the cached path
+# matches calls within the repo which expect
+# "sentence-transformers/all-MiniLM-L6-v2".
+SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
 PY
 
 # Pre-download the default chat model used in talk mode


### PR DESCRIPTION
## Summary
- pre-download the embedding model using the fully qualified model name so the onboarding demo and tests can load it offline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9bbd85588329a28e8c91be935444