### PR TITLE
Fix packaging of experiments module

### DIFF
--- a/gist_memory/experiments/__init__.py
+++ b/gist_memory/experiments/__init__.py
@@ -1,0 +1,3 @@
+from .config import ExperimentConfig, DatasetLoader
+
+__all__ = ["ExperimentConfig", "DatasetLoader"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ ray = ["ray[tune]"]
 
 [project.scripts]
 gist-memory = "gist_memory.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["gist_memory*"]
+
+[tool.setuptools.package-data]
+"gist_memory" = ["py.typed"]


### PR DESCRIPTION
## Summary
- expose `ExperimentConfig` via a new `experiments` package
- explicitly include package data in setuptools config

## Testing
- `pytest tests/test_experiment_runner.py::test_run_experiment -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_683dcf374964832986253edaf6a03823