### PR TITLE
Fix package discovery and expose StrategyConfig

### DIFF
--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
     "PrototypeSystemStrategy",
     "ValidationMetric",
     "run_params_trial",
+    "StrategyConfig",
 ]
 
 _lazy_map = {
@@ -87,6 +88,7 @@ _lazy_map = {
     "PrototypeSystemStrategy": "gist_memory.prototype_system_strategy",
     "ValidationMetric": "gist_memory.validation.metrics_abc",
     "run_params_trial": "gist_memory.hpo",
+    "StrategyConfig": "gist_memory.compression",
 }
 
 

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -198,6 +198,7 @@ def stats(
         raise typer.Exit(code=1)
     agent = _load_agent(path)
     data = agent.get_statistics()
+    logging.debug("Collected statistics: %s", data)
     if json_output:
         typer.echo(json.dumps(data))
     else:

--- a/gist_memory/compression/__init__.py
+++ b/gist_memory/compression/__init__.py
@@ -6,6 +6,7 @@ from importlib import util
 from pathlib import Path
 
 from .strategies_abc import CompressedMemory, CompressionStrategy, CompressionTrace
+from .config import StrategyConfig
 
 # ---------------------------------------------------------------------------
 # Support legacy simple compression strategies defined in ``compression.py``.
@@ -16,9 +17,7 @@ from .strategies_abc import CompressedMemory, CompressionStrategy, CompressionTr
 #     from gist_memory.compression import NoCompression
 #
 _legacy_path = Path(__file__).resolve().parent.parent / "compression.py"
-_spec = util.spec_from_file_location(
-    "gist_memory._compression_legacy", _legacy_path
-)
+_spec = util.spec_from_file_location("gist_memory._compression_legacy", _legacy_path)
 _legacy = util.module_from_spec(_spec)
 assert _spec.loader is not None  # for mypy/static checkers
 _spec.loader.exec_module(_legacy)
@@ -38,4 +37,5 @@ __all__ = [
     "register_compression_strategy",
     "get_compression_strategy",
     "available_strategies",
+    "StrategyConfig",
 ]

--- a/gist_memory/compression/config.py
+++ b/gist_memory/compression/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from .strategies_abc import CompressionStrategy
+
+
+@dataclass
+class StrategyConfig:
+    """Configuration for creating a :class:`CompressionStrategy`."""
+
+    strategy_name: str
+    strategy_params: Dict[str, Any] = field(default_factory=dict)
+
+    def create(self) -> CompressionStrategy:
+        """Instantiate the configured strategy."""
+        from . import get_compression_strategy
+
+        cls = get_compression_strategy(self.strategy_name)
+        return cls(**self.strategy_params)
+
+
+__all__ = ["StrategyConfig"]

--- a/gist_memory/response_experiment.py
+++ b/gist_memory/response_experiment.py
@@ -12,7 +12,7 @@ import yaml
 from .agent import Agent
 from .active_memory_manager import ActiveMemoryManager, ConversationTurn
 from .json_npy_store import JsonNpyVectorStore
-from .embedding_pipeline import embed_text, get_embedding_dim
+from .embedding_pipeline import embed_text, get_embedding_dim, MockEncoder
 from .chunker import SentenceWindowChunker
 from .registry import get_validation_metric_class
 from . import validation  # ensure metrics are registered
@@ -58,7 +58,9 @@ def _evaluate_sample(
 
     work_dir = tempfile.mkdtemp()
     dim = get_embedding_dim()
-    store = JsonNpyVectorStore(path=work_dir, embedding_model="experiment", embedding_dim=dim)
+    store = JsonNpyVectorStore(
+        path=work_dir, embedding_model="experiment", embedding_dim=dim
+    )
     agent = Agent(store, chunker=SentenceWindowChunker())
 
     for turn in sample["turns"]:
@@ -73,7 +75,9 @@ def _evaluate_sample(
     query = sample["query"]
     answer = sample.get("answer", "")
     if strategy is not None:
-        reply, info = agent.process_conversational_turn(query, mgr, compression=strategy)
+        reply, info = agent.process_conversational_turn(
+            query, mgr, compression=strategy
+        )
     else:
         reply, info = agent.process_conversational_turn(query, mgr)
     tokens = info.get("prompt_tokens", 0)
@@ -92,7 +96,11 @@ def _evaluate_sample(
             original_query=query,
         )
 
-    return {"metrics": metric_scores, "prompt_tokens": tokens, "compression_ms": compression_ms}
+    return {
+        "metrics": metric_scores,
+        "prompt_tokens": tokens,
+        "compression_ms": compression_ms,
+    }
 
 
 def run_response_experiment(
@@ -106,9 +114,7 @@ def run_response_experiment(
 
     results = []
     for params in config.param_grid:
-        aggregates: Dict[str, Dict[str, float]] = {
-            m["id"]: {} for m in metric_entries
-        }
+        aggregates: Dict[str, Dict[str, float]] = {m["id"]: {} for m in metric_entries}
         total_tokens = 0
         total_time = 0.0
         for sample in dataset:
@@ -135,5 +141,4 @@ def run_response_experiment(
     return results
 
 
-__all__ = ["ResponseExperimentConfig", "run_response_experiment"]
-
+__all__ = ["ResponseExperimentConfig", "run_response_experiment", "MockEncoder"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ ray = ["ray[tune]"]
 gist-memory = "gist_memory.__main__:main"
 
 [tool.setuptools.packages.find]
-include = ["gist_memory*"]
+where = ["."]
+include = ["gist_memory", "gist_memory.*"]
 
 [tool.setuptools.package-data]
 "gist_memory" = ["py.typed"]


### PR DESCRIPTION
## Summary
- ensure packages are found correctly by setuptools
- add `StrategyConfig` dataclass for easy strategy creation
- expose `StrategyConfig` from package init modules
- re-export `MockEncoder` for backward compatibility
- log collected stats in CLI so log file is not empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ddc0ea37483298f956a661307221f