### PR TITLE
Refactor compress CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Run `gist-memory --help` to see available commands.
 Use the CLI to experiment with different compression strategies:
 
 ```bash
-gist-memory compress --strategy <strategy_name> --text "Your large text here..." --budget 500
+gist-memory compress "Your large text here..." --strategy <strategy_name> --budget 500
 gist-memory talk --strategy <strategy_name> --message "What can you tell me based on the compressed context?"
 ```
 


### PR DESCRIPTION
## Summary
- update README usage example
- refactor `compress` command to accept string, file, or directory inputs
- add helper functions for string/file/directory compression
- implement warning logic and tokenizer init
- extend CLI tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683de65db3ac83298f423b6e395e4e2f