### PR TITLE
Add CLI commands for compression evaluation and LLM prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,19 @@ This project requires **Python 3.11+**.
 Run `gist-memory --help` to see available commands.
 
 ## Core Workflow
-Use the CLI to experiment with different compression strategies:
+Use the CLI to experiment with different compression strategies and metrics:
 
 ```bash
 gist-memory compress "Your large text here..." --strategy <strategy_name> --budget 500
 gist-memory talk --strategy <strategy_name> --message "What can you tell me based on the compressed context?"
+
+# Evaluate compression quality directly
+gist-memory evaluate-compression original.txt compressed.txt --metric compression_ratio --json
+
+# Pipeline: compress -> prompt -> evaluate
+gist-memory compress file.txt --strategy none --budget 50 --output-trace trace.json \
+  | gist-memory llm-prompt --context - --query "Summarize" --model distilgpt2 \
+  | gist-memory evaluate-llm-response - "expected summary" --metric exact_match --json
 ```
 
 ### Running Tests

--- a/gist_memory/validation/__init__.py
+++ b/gist_memory/validation/__init__.py
@@ -7,6 +7,7 @@ from .hf_metrics import (
     BertScoreHFMetric,
     ExactMatchMetric,
 )
+from .compression_metrics import CompressionRatioMetric
 
 __all__ = [
     "ValidationMetric",
@@ -16,4 +17,5 @@ __all__ = [
     "MeteorHFMetric",
     "BertScoreHFMetric",
     "ExactMatchMetric",
+    "CompressionRatioMetric",
 ]

--- a/gist_memory/validation/compression_metrics.py
+++ b/gist_memory/validation/compression_metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Metrics for evaluating compression quality."""
+
+from typing import Dict
+
+from .metrics_abc import ValidationMetric
+from ..registry import register_validation_metric
+
+
+class CompressionRatioMetric(ValidationMetric):
+    """Ratio of compressed text length to original text length."""
+
+    metric_id = "compression_ratio"
+
+    def evaluate(self, *, original_text: str, compressed_text: str, **kwargs) -> Dict[str, float]:  # type: ignore[override]
+        if not original_text:
+            return {"compression_ratio": 0.0}
+        ratio = len(compressed_text) / len(original_text)
+        return {"compression_ratio": ratio}
+
+
+register_validation_metric(CompressionRatioMetric.metric_id, CompressionRatioMetric)
+
+__all__ = ["CompressionRatioMetric"]


### PR DESCRIPTION
## Summary
- add `compression_ratio` metric
- add new CLI options and commands
- implement `llm-prompt`, `evaluate-compression`, `evaluate-llm-response`
- add `strategy list` and `metric list` commands
- support saving compression trace from `compress`
- document CLI workflow in README
- extend CLI tests for new features

## Testing
- `pytest -q`
- `pytest tests/test_cli.py::test_cli_output_trace tests/test_cli.py::test_cli_strategy_and_metric_list tests/test_cli.py::test_cli_evaluate_compression tests/test_cli.py::test_cli_llm_prompt tests/test_cli.py::test_cli_evaluate_llm_response -q`

------
https://chatgpt.com/codex/tasks/task_e_683df17783208329a7a41d9d78900b72