### PR TITLE
Implement plugin system for compression strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ For more detailed information on Gist Memory's architecture, development guides,
 -   **Developing Compression Strategies:** Learn how to create your own strategies in `docs/DEVELOPING_COMPRESSION_STRATEGIES.md`.
 -   **Developing Validation Metrics:** Find guidance on building custom metrics in `docs/DEVELOPING_VALIDATION_METRICS.md`.
 -   **Running Experiments:** Details on the experimentation framework can be found in `docs/RUNNING_EXPERIMENTS.md`.
+-   **Plugins:** Learn how to install or develop strategy plugins in `docs/SHARING_STRATEGIES.md`.
 -   **Conceptual Guides:** Explore the ideas behind memory strategies in `AGENTS.md`.
 
 ## Designing Compression Strategies

--- a/docs/SHARING_STRATEGIES.md
+++ b/docs/SHARING_STRATEGIES.md
@@ -38,3 +38,34 @@ Run an experiment from a package with:
 ```
 gist-memory experiment run-package /path/to/package --experiment experiments/example.yaml
 ```
+
+## Using Strategy Packages as Plugins
+
+Installable Python packages can register a strategy via the
+`gist_memory.strategies` entry point group. A minimal `pyproject.toml` snippet:
+
+```toml
+[project.entry-points."gist_memory.strategies"]
+my_strategy = "my_package.module:MyStrategy"
+```
+
+When such a package is installed, the strategy is automatically discovered on
+startup.
+
+For local experimentation, place a strategy package directory inside
+`$GIST_MEMORY_PLUGINS_PATH` or the default user plugin directory
+`$(platformdirs.user_data_dir('gist_memory','GistMemoryTeam'))/plugins`. Multiple
+paths may be provided in `GIST_MEMORY_PLUGINS_PATH` separated by the system path
+separator. Paths listed first take precedence.
+
+The override order is:
+
+1. Built-in strategies
+2. Entry point plugins
+3. Local plugin directories (highest precedence)
+
+Use `gist-memory strategy list` to verify which strategy implementation is active
+and its source.
+
+**Security Warning:** Loading plugins executes arbitrary code. Only install or
+place plugins from sources you trust.

--- a/gist_memory/compression/__init__.py
+++ b/gist_memory/compression/__init__.py
@@ -27,6 +27,8 @@ ImportanceCompression = _legacy.ImportanceCompression
 register_compression_strategy = _legacy.register_compression_strategy
 get_compression_strategy = _legacy.get_compression_strategy
 available_strategies = _legacy.available_strategies
+get_strategy_metadata = _legacy.get_strategy_metadata
+all_strategy_metadata = _legacy.all_strategy_metadata
 
 __all__ = [
     "CompressedMemory",
@@ -37,5 +39,7 @@ __all__ = [
     "register_compression_strategy",
     "get_compression_strategy",
     "available_strategies",
+    "get_strategy_metadata",
+    "all_strategy_metadata",
     "StrategyConfig",
 ]

--- a/gist_memory/plugin_loader.py
+++ b/gist_memory/plugin_loader.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+"""Discovery and registration of compression strategy plugins."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import importlib.metadata as metadata
+import logging
+import os
+from typing import Iterable
+
+from platformdirs import user_data_dir
+
+from .compression import register_compression_strategy, get_strategy_metadata
+from .compression.strategies_abc import CompressionStrategy
+from .package_utils import (
+    validate_package_dir,
+    load_manifest,
+    load_strategy_class_from_module,
+)
+
+
+PLUGIN_ENV_VAR = "GIST_MEMORY_PLUGINS_PATH"
+ENTRYPOINT_GROUP = "gist_memory.strategies"
+DEFAULT_PLUGIN_DIR = Path(user_data_dir("gist_memory", "GistMemoryTeam")) / "plugins"
+
+
+_loaded = False
+
+
+@dataclass
+class PluginPath:
+    path: Path
+    source_label: str
+
+
+def _iter_local_plugin_paths() -> Iterable[PluginPath]:
+    env = os.getenv(PLUGIN_ENV_VAR)
+    if env:
+        for idx, raw in enumerate(env.split(os.pathsep)):
+            if not raw:
+                continue
+            yield PluginPath(Path(raw), f"local ({Path(raw).name})")
+    yield PluginPath(DEFAULT_PLUGIN_DIR, f"local ({DEFAULT_PLUGIN_DIR.name})")
+
+
+def load_plugins() -> None:
+    """Discover and register all compression strategy plugins."""
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    _load_entrypoint_plugins()
+    _load_local_plugins()
+
+
+def _load_entrypoint_plugins() -> None:
+    try:
+        eps = metadata.entry_points(group=ENTRYPOINT_GROUP)
+    except TypeError:  # pragma: no cover - older Python
+        eps = metadata.entry_points().get(ENTRYPOINT_GROUP, [])
+
+    for ep in eps:
+        try:
+            cls = ep.load()
+            if not isinstance(cls, type) or not issubclass(cls, CompressionStrategy):
+                raise TypeError("Entry point is not a CompressionStrategy")
+            dist_name = None
+            version = None
+            try:
+                if ep.dist:
+                    dist_name = ep.dist.metadata.get("Name")
+                    version = ep.dist.version
+            except Exception:
+                pass
+            strategy_id = getattr(cls, "id")
+            display_name = getattr(cls, "display_name", strategy_id)
+            prev = get_strategy_metadata(strategy_id)
+            if prev:
+                logging.info(
+                    "Entry point plugin '%s' overrides %s strategy '%s'",
+                    ep.value,
+                    prev.get("source"),
+                    strategy_id,
+                )
+            register_compression_strategy(
+                strategy_id,
+                cls,
+                display_name=display_name,
+                version=version,
+                source=f"plugin ({dist_name or 'unknown'})",
+            )
+        except Exception as exc:
+            logging.warning("Failed to load entry point %s: %s", ep.value, exc)
+
+
+def _load_local_plugins() -> None:
+    for pp in _iter_local_plugin_paths():
+        if not pp.path.exists():
+            continue
+        for pkg_dir in sorted(p for p in pp.path.iterdir() if p.is_dir()):
+            try:
+                errors, _ = validate_package_dir(pkg_dir)
+                if errors:
+                    logging.warning(
+                        "Invalid plugin at %s: %s", pkg_dir, ", ".join(errors)
+                    )
+                    continue
+                manifest = load_manifest(pkg_dir / "strategy_package.yaml")
+                strategy_id = manifest.get("strategy_id")
+                display_name = manifest.get("display_name", strategy_id)
+                version = manifest.get("version")
+                module_file = pkg_dir / f"{manifest['strategy_module']}.py"
+                cls = load_strategy_class_from_module(
+                    str(module_file), manifest["strategy_class_name"]
+                )
+                prev = get_strategy_metadata(strategy_id)
+                if prev:
+                    logging.info(
+                        "Local plugin '%s' overrides %s strategy '%s'",
+                        pkg_dir,
+                        prev.get("source"),
+                        strategy_id,
+                    )
+                register_compression_strategy(
+                    strategy_id,
+                    cls,
+                    display_name=display_name,
+                    version=version,
+                    source=pp.source_label,
+                )
+            except Exception as exc:
+                logging.warning("Failed loading plugin from %s: %s", pkg_dir, exc)
+
+
+__all__ = [
+    "load_plugins",
+    "PLUGIN_ENV_VAR",
+    "ENTRYPOINT_GROUP",
+    "DEFAULT_PLUGIN_DIR",
+]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,73 @@
+import sys
+from importlib.metadata import EntryPoint
+import yaml
+from typer.testing import CliRunner
+
+from gist_memory.cli import app
+from gist_memory import plugin_loader
+from gist_memory.compression import get_compression_strategy, get_strategy_metadata
+
+
+def _write_local_plugin(path, name, text):
+    path.mkdir(parents=True)
+    (path / "strategy.py").write_text(text)
+    manifest = {
+        "package_format_version": "1.0",
+        "strategy_id": name,
+        "strategy_class_name": "LocalStrategy",
+        "strategy_module": "strategy",
+        "display_name": "LocalStrategy",
+        "version": "0.0.1",
+        "authors": [],
+        "description": "test",
+    }
+    (path / "strategy_package.yaml").write_text(yaml.safe_dump(manifest))
+    (path / "requirements.txt").write_text("\n")
+    (path / "README.md").write_text("hi")
+
+
+def test_plugin_override_chain(tmp_path, monkeypatch):
+    ep_mod = tmp_path / "epmod.py"
+    ep_mod.write_text(
+        "from gist_memory.compression.strategies_abc import CompressionStrategy, CompressedMemory, CompressionTrace\n"
+        "class EpStrategy(CompressionStrategy):\n"
+        "    id='none'\n"
+        "    display_name='EP'\n"
+        "    def compress(self, t, llm_token_budget, **k):\n"
+        "        return CompressedMemory(text='ep'), CompressionTrace()\n"
+    )
+    monkeypatch.syspath_prepend(tmp_path)
+    ep = EntryPoint(name="ep", value="epmod:EpStrategy", group=plugin_loader.ENTRYPOINT_GROUP)
+    monkeypatch.setattr(
+        plugin_loader.metadata,
+        "entry_points",
+        lambda group=None: [ep] if group == plugin_loader.ENTRYPOINT_GROUP else [],
+    )
+
+    local_root = tmp_path / "local"
+    plugin_dir = local_root / "plugin"
+    _write_local_plugin(
+        plugin_dir,
+        "none",
+        "from gist_memory.compression.strategies_abc import CompressionStrategy, CompressedMemory, CompressionTrace\n"
+        "class LocalStrategy(CompressionStrategy):\n"
+        "    id='none'\n"
+        "    display_name='Local'\n"
+        "    def compress(self, t, llm_token_budget, **k):\n"
+        "        return CompressedMemory(text='local'), CompressionTrace()\n",
+    )
+    monkeypatch.setenv(plugin_loader.PLUGIN_ENV_VAR, str(local_root))
+
+    plugin_loader._loaded = False
+    plugin_loader.load_plugins()
+
+    cls = get_compression_strategy("none")
+    assert cls.__name__ == "LocalStrategy"
+    info = get_strategy_metadata("none")
+    assert info["source"].startswith("local")
+    assert info["overrides"] == "plugin (unknown)"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["strategy", "list"])
+    assert result.exit_code == 0
+    assert "Local" in result.stdout


### PR DESCRIPTION
## Summary
- add plugin discovery loader supporting entry points and local directories
- extend compression registry to store plugin metadata
- integrate plugin loading into CLI and enhance `strategy list`
- document plugin usage and directory layout
- test plugin override chain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e0a44a1188329a5fe4c4231e36ab7