### PR TITLE
Optimize disk usage in CI and setup scripts

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -10,6 +10,7 @@ apt-get update
 
 # Install Python and basic tools
 apt-get install -y --no-install-recommends python3 python3-pip git
+apt-get clean
 
 # Install Python dependencies for the repository and download spaCy model
 if [ -f requirements.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir pytest
       - name: Run tests
         run: pytest


### PR DESCRIPTION
This commit introduces two optimizations to reduce disk space consumption during dependency installation:

1.  **Clean apt cache in `.codex/setup.sh`:** Added `apt-get clean` after `apt-get install` to remove downloaded package files.
2.  **Disable pip cache in CI:** Added `--no-cache-dir` to `pip install` commands in the GitHub Actions workflow (`.github/workflows/ci.yml`) to prevent caching.

These changes aim to resolve issues where tests fail due to insufficient disk space when installing dependencies.