### PR TITLE
Fix: Correct gist-memory compress command for text input in notebook

### DIFF
--- a/examples/gist_memory_showcase.ipynb
+++ b/examples/gist_memory_showcase.ipynb
@@ -236,7 +236,7 @@
     "# Example: Compress a short text string using the 'truncate' strategy (if available as a built-in/plugin)\n",
     "# This command demonstrates compressing a simple line of text. \n",
     "# We use the 'truncate' strategy to keep the beginning of the text, fitting it within a 20-token budget.\n",
-    "!gist-memory compress --strategy truncate --text \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
+    "!gist-memory compress --strategy truncate \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
     "\n",
     "# Example: Compress a text file using the 'gist' strategy\n",
     "# This command demonstrates compressing an entire file. We use 'sample_data/moon_landing/full.txt'.\n",
@@ -267,7 +267,7 @@
     "# We use the 'sample_data/moon_landing' directory.\n",
     "# The 'gist' strategy will be applied to each file.\n",
     "# The `compress` command directly handles directory paths.\n",
-    "!gist-memory compress --strategy gist --file sample_data/moon_landing --budget 200\n",
+    "!gist-memory compress --strategy gist sample_data/moon_landing --budget 200\n",
     "# You might want to add --output some_directory_output.json if you want to inspect results later"
    ]
   },


### PR DESCRIPTION
The `gist-memory compress` command in `examples/gist_memory_showcase.ipynb` was incorrectly using the `--text` option when compressing a raw string. The CLI expects the input string as a positional argument.

This commit changes the command to pass the string as a positional argument.

The command was changed from:
`!gist-memory compress --strategy truncate --text "..." --budget 20`

To:
`!gist-memory compress --strategy truncate "..." --budget 20`