### PR TITLE
Switch default chat model to tiny-gpt2

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -41,8 +41,8 @@ PY
 python3 - <<'PY'
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-AutoTokenizer.from_pretrained("distilgpt2")
-AutoModelForCausalLM.from_pretrained("distilgpt2")
+AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
 PY
 
 # Ensure the GPT-2 tokenizer files are available for tiktoken

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This project requires **Python 3.11+**.
     # Fetch the "all-MiniLM-L6-v2" model for embedding (used by default LTM components)
     gist-memory download-model --model-name all-MiniLM-L6-v2
     # Fetch a default chat model for the 'talk' command and LLM-based validation
-    gist-memory download-chat-model --model-name distilgpt2
+    gist-memory download-chat-model --model-name tiny-gpt2
     ```
     Note: Specific `CompressionStrategy` implementations might have other model dependencies not covered here. Always check the documentation for the strategy you intend to use.
     To run completely offline after all downloads, set:
@@ -165,12 +165,12 @@ This compares the original text with its compressed version using a specific met
 A more complex workflow that simulates a full cycle: compress information, use it to prompt an LLM, and then evaluate the LLM's response.
 ```bash
 gist-memory compress file.txt --strategy none --budget 50 --output-trace trace.json \
-  | gist-memory llm-prompt --context - --query "Summarize the provided text." --model distilgpt2 \
+  | gist-memory llm-prompt --context - --query "Summarize the provided text." --model tiny-gpt2 \
   | gist-memory evaluate-llm-response - "An accurate summary would be..." --metric exact_match --json
 ```
 This example:
 - Compresses `file.txt` using a (hypothetical) `none` strategy with a budget of 50 tokens, saving a trace.
-- Pipes the compressed output (`-`) to `llm-prompt` to ask a distilgpt2 model to summarize it.
+ - Pipes the compressed output (`-`) to `llm-prompt` to ask a tiny-gpt2 model to summarize it.
 - Pipes the LLM's response (`-`) to `evaluate-llm-response` to check if it matches an expected summary using the `exact_match` metric.
 
 ### Running Tests

--- a/examples/gist_memory_showcase.ipynb
+++ b/examples/gist_memory_showcase.ipynb
@@ -163,7 +163,7 @@
    "outputs": [],
    "source": [
     "# Download a small chat model for demonstration purposes\n",
-    "!gist-memory download-chat-model --model-name distilgpt2"
+    "!gist-memory download-chat-model --model-name tiny-gpt2"
    ]
   },
   {
@@ -339,9 +339,9 @@
     "\n",
     "1.  **Talk with a strategy applied to the ongoing conversation history:**\n",
     "    ```bash\n",
-    "    gist-memory talk --strategy gist --chat-model distilgpt2 --budget 150\n",
+    "    gist-memory talk --strategy gist --chat-model tiny-gpt2 --budget 150\n",
     "    ```\n",
-    "    This starts an interactive session where `distilgpt2` is the LLM, and the `gist` strategy compresses the conversation history to about 150 tokens before each LLM call.\n",
+    "    This starts an interactive session where `tiny-gpt2` is the LLM, and the `gist` strategy compresses the conversation history to about 150 tokens before each LLM call.\n",
     "\n",
     "2.  **Talk using a pre-compressed memory file:**\n",
     "    First, compress a document (using path relative to repo root):\n",
@@ -350,7 +350,7 @@
     "    ```\n",
     "    Then, start a conversation using this memory as initial context:\n",
     "    ```bash\n",
-    "    gist-memory talk --memory moon_memory.json --chat-model distilgpt2 --message \"What were the main objectives?\"\n",
+    "    gist-memory talk --memory moon_memory.json --chat-model tiny-gpt2 --message \"What were the main objectives?\"\n",
     "    ```\n",
     "\n",
     "For a non-interactive check within the notebook, you can try sending a single message. The behavior might vary:\n"
@@ -365,7 +365,7 @@
    "source": [
     "# This attempts a non-interactive query using the 'truncate' strategy with a specified chat model.\n",
     "# The CLI might provide a single response or indicate it's for interactive use.\n",
-    "!gist-memory talk --strategy truncate --chat-model distilgpt2 --message \"What is the capital of France?\" --budget 50"
+    "!gist-memory talk --strategy truncate --chat-model tiny-gpt2 --message \"What is the capital of France?\" --budget 50"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "\n",
     "The `gist-memory` CLI offers other utilities. Here are a few, with examples of how to get their help messages:\n",
     "\n",
-    "-   `download-model`, `download-chat-model`: We used these in the setup to fetch models (e.g., `all-MiniLM-L6-v2`, `distilgpt2`).\n",
+    "-   `download-model`, `download-chat-model`: We used these in the setup to fetch models (e.g., `all-MiniLM-L6-v2`, `tiny-gpt2`).\n",
     "-   `stats`: Provides statistics about datasets or memory files.\n",
     "-   `validate`: Validates configuration files or memory formats against the library's schemas."
    ],
@@ -791,7 +791,7 @@
     "\n",
     "A response experiment assesses how compressed memory affects the quality of responses from an LLM. It uses a dataset of dialogues where the task is to generate a response based on the history.\n",
     "\n",
-    "**Note**: This experiment can take longer to run as it involves calls to an LLM (even a small local one like `distilgpt2`). The `truncate` strategy's impact on response quality might be detrimental if too much context is lost."
+    "**Note**: This experiment can take longer to run as it involves calls to an LLM (even a small local one like `tiny-gpt2`). The `truncate` strategy's impact on response quality might be detrimental if too much context is lost."
    ],
    "metadata": {}
   },
@@ -814,7 +814,7 @@
     "        dataset_path=str(response_dialogues_data_path),\n",
     "        # Using integer for token_budget\n",
     "        param_grid={\"token_budget\": [100]},\n",
-    "        chat_model_name=\"distilgpt2\", # LLM for generating responses\n",
+    "        chat_model_name=\"tiny-gpt2\", # LLM for generating responses\n",
     "        output_dir=\"./response_experiment_output\"\n",
     "    )\n",
     "\n",

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -326,7 +326,7 @@ def talk(
     *,
     agent_name: str = typer.Option(DEFAULT_BRAIN_PATH, help="Agent directory"),
     message: str = typer.Option(..., help="Message to send"),
-    model_name: str = typer.Option("distilgpt2", help="Local chat model"),
+    model_name: str = typer.Option("tiny-gpt2", help="Local chat model"),
     compression_strategy: Optional[str] = typer.Option(
         None,
         "--compression",
@@ -719,7 +719,7 @@ def llm_prompt(
     *,
     context_input: str = typer.Option(..., "--context", "-c", help="Compressed context string, path, or '-' for stdin"),
     query: str = typer.Option(..., "--query", "-q", help="User query"),
-    model_id: str = typer.Option("distilgpt2", "--model", help="Model ID"),
+    model_id: str = typer.Option("tiny-gpt2", "--model", help="Model ID"),
     system_prompt: Optional[str] = typer.Option(None, "--system-prompt", "-s", help="Optional system prompt"),
     max_new_tokens: int = typer.Option(150, help="Max new tokens"),
     output_llm_response_file: Optional[Path] = typer.Option(None, "--output-response", help="File to save response"),
@@ -966,7 +966,7 @@ def download_model(
 
 @app.command("download-chat-model")
 def download_chat_model(
-    model_name: str = typer.Option("distilgpt2", help="Local causal LM name"),
+    model_name: str = typer.Option("tiny-gpt2", help="Local causal LM name"),
 ) -> None:
     """
     Pre-downloads a specified local language model for use with the `talk` command.
@@ -975,7 +975,7 @@ def download_chat_model(
     the `talk` command's first run and is helpful for offline usage.
 
     Usage Example:
-        gist-memory download-chat-model --model-name distilgpt2
+        gist-memory download-chat-model --model-name tiny-gpt2
     """
     # from tqdm import tqdm # Moved to top
     # from .model_utils import download_chat_model as _download_chat_model # Moved to top

--- a/gist_memory/local_llm.py
+++ b/gist_memory/local_llm.py
@@ -27,7 +27,7 @@ except Exception:  # pragma: no cover - optional
 class LocalChatModel(LLMProvider):
     """Wrap a local `transformers` causal LM for offline chat."""
 
-    model_name: str = "distilgpt2"
+    model_name: str = "tiny-gpt2"
     max_new_tokens: int = 100
 
     tokenizer: Optional["AutoTokenizer"] = None  # set in ``__post_init__``

--- a/llm_models_config.yaml
+++ b/llm_models_config.yaml
@@ -21,3 +21,8 @@ distilgpt2:
   provider: local
   model_name: distilgpt2
   token_budget: 1024
+
+tiny-gpt2:
+  provider: local
+  model_name: sshleifer/tiny-gpt2
+  token_budget: 512

--- a/setup.sh
+++ b/setup.sh
@@ -9,4 +9,4 @@ python -m spacy download en_core_web_sm
 
 # Pre-fetch models used in the examples and tests
 gist-memory download-model --model-name all-MiniLM-L6-v2
-gist-memory download-chat-model --model-name distilgpt2
+gist-memory download-chat-model --model-name tiny-gpt2

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -140,9 +140,9 @@ def test_provider_interface(monkeypatch):
     )
 
     model = LocalChatModel()
-    budget = model.get_token_budget("distilgpt2")
+    budget = model.get_token_budget("tiny-gpt2")
     assert isinstance(budget, int) and budget > 0
-    tokens = model.count_tokens("hello", "distilgpt2")
+    tokens = model.count_tokens("hello", "tiny-gpt2")
     assert tokens == 1
-    reply = model.generate_response("prompt", "distilgpt2", 10)
+    reply = model.generate_response("prompt", "tiny-gpt2", 10)
     assert reply == "response"


### PR DESCRIPTION
## Summary
- download the much smaller `sshleifer/tiny-gpt2` model in setup scripts
- add `tiny-gpt2` configuration for local models
- use `tiny-gpt2` as the default local model in the CLI and library
- update README and example notebook
- update tests to reference the new tiny model

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e3db7eb4083299ccff82adc211919