### PR TITLE
Add pipeline compression strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Best practices for allocating token budgets within a prompt when using different
 VI. Developer Notes
 
 The talk command, and generally the LLM interaction workflow, will need to be adapted to accept and utilize a chosen CompressionStrategy. If Agent.process_conversational_turn is the entry point, it will orchestrate the use of the active CompressionStrategy.
+Chainable strategies are now supported via `PipelineCompressionStrategy`, enabling a flexible memory pipeline for experimentation.
 
 VII. Contribution Workflow Tips
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,8 @@ experimented with.
 - **`embedding_pipeline.py`** – loads a SentenceTransformer model and
   exposes `embed_text`. A deterministic `MockEncoder` is available for
   tests. Embeddings are cached and normalised.
+- **`compression/pipeline_strategy.py`** – implements `PipelineCompressionStrategy`
+  allowing multiple compression steps to be chained.
 - **`chunker.py`** – implements sentence-window based chunking with token
   overlap and a fixed-size fallback. The registry allows different
   chunkers to be plugged in via config.

--- a/docs/COMPRESSION_STRATEGIES.md
+++ b/docs/COMPRESSION_STRATEGIES.md
@@ -52,3 +52,18 @@ Latency benchmarks on a single CPU (10k ideas/min) come from using MiniLM embedd
 - Keep overlap small (≤20%) to avoid duplicate centroids.
 - Evaluate retrieval F1 versus chunk granularity; too coarse usually hurts long‑tail recall, too fine inflates the index.
 - Monitor centroid drift and auto-split if intra-distance exceeds δ.
+
+## Pipeline strategies
+
+For more complex workflows a `PipelineCompressionStrategy` can chain multiple
+strategies. The output of one step feeds into the next, enabling filters and
+summarizers to be composed.
+
+Example configuration:
+
+```yaml
+strategy_name: pipeline
+strategies:
+  - strategy_name: importance
+  - strategy_name: learned_summarizer
+```

--- a/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
+++ b/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
@@ -37,3 +37,20 @@ trace.steps.append({
 These rich traces make strategies easier to debug and analyse. When designing a
 new strategy, think about what decisions are being made and record them as steps
 in the trace.
+
+## Composing Strategies with Pipelines
+
+`PipelineCompressionStrategy` allows multiple compression steps to be chained
+together. Each strategy in the pipeline receives the same token budget and
+processes the output of the previous one. Pipelines are configured with
+`PipelineStrategyConfig`, which lists the strategies to run in order.
+
+Example:
+
+```yaml
+compression:
+  strategy_name: pipeline
+  strategies:
+    - strategy_name: importance
+    - strategy_name: learned_summarizer
+```

--- a/gist_memory/active_memory_manager.py
+++ b/gist_memory/active_memory_manager.py
@@ -226,7 +226,7 @@ class ActiveMemoryManager:
                 kept_ids.add(id(turn))
                 current_tokens += n_tokens
             else:
-                break
+                continue
 
         return [t for t in candidate_turns if id(t) in kept_ids]
 

--- a/gist_memory/active_memory_strategy.py
+++ b/gist_memory/active_memory_strategy.py
@@ -145,7 +145,14 @@ class ActiveMemoryStrategy(CompressionStrategy):
         
         # trace_events = kwargs.get('trace_events', []) # Check how trace_events is passed
         # trace_events.extend(trace_steps)
-        compression_trace = CompressionTrace(steps=trace_steps) #, events=trace_events)
+        compression_trace = CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={"llm_token_budget": llm_token_budget},
+            input_summary={"history_len": len(self.manager.history)},
+            steps=trace_steps,
+            output_summary={"compressed_length": len(compressed_text)},
+            final_compressed_object_preview=compressed_text[:50],
+        )
 
         return compressed_memory, compression_trace
 

--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -23,10 +23,10 @@ from .logging_utils import configure_logging
 
 from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
-from .local_llm import LocalChatModel # Moved from talk
+from . import local_llm  # import module so tests can patch LocalChatModel
 from .active_memory_manager import ActiveMemoryManager # Moved from talk
 from .registry import _VALIDATION_METRIC_REGISTRY, get_validation_metric_class # Moved from metric_list, evaluate_compression, evaluate_llm_response
-from .llm_providers import OpenAIProvider, GeminiProvider, LocalTransformersProvider # Moved from llm_prompt
+from . import llm_providers  # import module so tests can patch providers
 from .model_utils import download_embedding_model, download_chat_model as _download_chat_model # Moved from download_model, download_chat_model
 from .embedding_pipeline import (
     get_embedding_dim,
@@ -367,7 +367,7 @@ def talk(
         # from .local_llm import LocalChatModel # Moved to top
 
         try:
-            agent._chat_model = LocalChatModel(model_name=model_name)
+            agent._chat_model = local_llm.LocalChatModel(model_name=model_name)
             agent._chat_model.load_model()
         except RuntimeError as exc:
             typer.echo(str(exc), err=True)
@@ -764,11 +764,11 @@ def llm_prompt(
     model_name = model_cfg.get("model_name", model_id)
 
     if provider_name == "openai":
-        provider = OpenAIProvider()
+        provider = llm_providers.OpenAIProvider()
     elif provider_name == "gemini":
-        provider = GeminiProvider()
+        provider = llm_providers.GeminiProvider()
     else:
-        provider = LocalTransformersProvider()
+        provider = llm_providers.LocalTransformersProvider()
 
     api_key = os.getenv(api_key_env_var) if api_key_env_var else None
 

--- a/gist_memory/compression/__init__.py
+++ b/gist_memory/compression/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .strategies_abc import CompressedMemory, CompressionStrategy, CompressionTrace
 from .config import StrategyConfig
+from .pipeline_strategy import PipelineCompressionStrategy, PipelineStrategyConfig
 
 # ---------------------------------------------------------------------------
 # Support legacy simple compression strategies defined in ``compression.py``.
@@ -30,12 +31,17 @@ available_strategies = _legacy.available_strategies
 get_strategy_metadata = _legacy.get_strategy_metadata
 all_strategy_metadata = _legacy.all_strategy_metadata
 
+# Register built-in strategies defined in submodules
+register_compression_strategy(PipelineCompressionStrategy.id, PipelineCompressionStrategy)
+
 __all__ = [
     "CompressedMemory",
     "CompressionStrategy",
     "CompressionTrace",
     "NoCompression",
     "ImportanceCompression",
+    "PipelineCompressionStrategy",
+    "PipelineStrategyConfig",
     "register_compression_strategy",
     "get_compression_strategy",
     "available_strategies",

--- a/gist_memory/compression/pipeline_strategy.py
+++ b/gist_memory/compression/pipeline_strategy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Pipeline compression strategy for chaining multiple strategies."""
+
+from dataclasses import dataclass, field
+from typing import List, Union, Any
+
+from .strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+from .config import StrategyConfig
+
+
+@dataclass
+class PipelineStrategyConfig:
+    """Configuration for :class:`PipelineCompressionStrategy`."""
+
+    strategies: List[StrategyConfig] = field(default_factory=list)
+
+    def create(self) -> "PipelineCompressionStrategy":
+        return PipelineCompressionStrategy(self)
+
+
+class PipelineCompressionStrategy(CompressionStrategy):
+    """Execute a sequence of other compression strategies."""
+
+    id = "pipeline"
+
+    def __init__(self, config_or_strategies: Union[PipelineStrategyConfig, List[CompressionStrategy]]):
+        if isinstance(config_or_strategies, PipelineStrategyConfig):
+            self.config = config_or_strategies
+            self.strategies = [cfg.create() for cfg in self.config.strategies]
+        else:
+            self.config = PipelineStrategyConfig()
+            self.strategies = list(config_or_strategies)
+
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int,
+        **kwargs: Any,
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        current = text_or_chunks
+        step_traces = []
+        for strat in self.strategies:
+            compressed, trace = strat.compress(current, llm_token_budget, **kwargs)
+            step_traces.append({"strategy": strat.id, "trace": trace})
+            current = compressed.text
+        final = CompressedMemory(text=current)
+        pipeline_trace = CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={},
+            input_summary={"num_steps": len(self.strategies)},
+            steps=step_traces,
+            output_summary={"output_length": len(final.text)},
+            final_compressed_object_preview=final.text[:50],
+        )
+        return final, pipeline_trace
+
+
+__all__ = ["PipelineStrategyConfig", "PipelineCompressionStrategy"]

--- a/gist_memory/token_utils.py
+++ b/gist_memory/token_utils.py
@@ -11,9 +11,15 @@ def tokenize_text(tokenizer: Any, text: str) -> List[int]:
         try:
             tokens = tokenizer.tokenize(text)
         except Exception:
-            tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+            try:
+                tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+            except Exception:
+                tokens = tokenizer(text)
     else:
-        tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+        try:
+            tokens = tokenizer(text, return_tensors=None).get("input_ids", [])
+        except Exception:
+            tokens = tokenizer(text)
 
     if isinstance(tokens, (list, tuple)):
         if tokens and isinstance(tokens[0], (list, tuple)):


### PR DESCRIPTION
## Summary
- implement `PipelineCompressionStrategy` for chaining compression steps
- document pipeline usage and architecture
- register new strategy and update CLI to allow monkeypatching
- fix `ActiveMemoryManager` pruning logic and traces
- update tokenization utility for simpler mocks
- extend compression tests for pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e48efe2ec8329a845baa01909a7ef