### PR TITLE
Fix: Correct CLI calls and imports in gist_memory_showcase.ipynb

### DIFF
--- a/examples/gist_memory_showcase.ipynb
+++ b/examples/gist_memory_showcase.ipynb
@@ -221,7 +221,7 @@
    "source": [
     "### 2.2 Compression Command (`compress`)\n",
     "\n",
-    "The `compress` command lets you apply a compression strategy to various forms of input: a direct line of text, a single file, or an entire directory. The following subsections will demonstrate each of these use cases.\n",
+    "The `compress` command lets you apply a compression strategy to various forms of input: a direct line of text (using `--text`), or a single file or an entire directory (by providing the path as a positional argument). The following subsections will demonstrate these use cases.\n",
     "\n",
     "**Important Note**: The CLI uses strategies that are built into `gist-memory` or registered via its plugin system. The custom `TruncateStrategy` we defined and registered within this Python notebook session is *not* automatically available to the standalone CLI. For CLI examples, we'll use `truncate` if it's a built-in alias for a simple truncation strategy, or another standard built-in strategy like `gist` (which aims to create a gist of the text)."
    ],
@@ -236,13 +236,13 @@
     "# Example: Compress a short text string using the 'truncate' strategy (if available as a built-in/plugin)\n",
     "# This command demonstrates compressing a simple line of text. \n",
     "# We use the 'truncate' strategy to keep the beginning of the text, fitting it within a 20-token budget.\n",
-    "!gist-memory compress --strategy truncate \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
+    "!gist-memory compress --strategy truncate --text \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
     "\n",
     "# Example: Compress a text file using the 'gist' strategy\n",
     "# This command demonstrates compressing an entire file. We use 'sample_data/moon_landing/full.txt'.\n",
     "# The 'gist' strategy is employed to summarize the content within a 100-token budget.\n",
-    "# The `compress` command directly handles file paths.\n",
-    "!gist-memory compress --strategy gist --file sample_data/moon_landing/full.txt --budget 100"
+    "# To compress a file, provide its path as an argument. For instance:\n",
+    "!gist-memory compress --strategy gist sample_data/moon_landing/full.txt --budget 100"
    ]
   },
   {
@@ -293,8 +293,8 @@
    "outputs": [],
    "source": [
     "# Example of using a different strategy (truncate) on the full.txt file\n",
-    "# The `compress` command directly handles file paths.\n",
-    "!gist-memory compress --strategy truncate --file sample_data/moon_landing/full.txt --budget 100"
+    "# To compress a file, provide its path as an argument. For instance:\n",
+    "!gist-memory compress --strategy truncate sample_data/moon_landing/full.txt --budget 100"
    ]
   },
   {
@@ -303,7 +303,7 @@
     "Common options for `gist-memory compress`:\n",
     "-   `--strategy <name>`: ID of the compression strategy (e.g., `gist`, `truncate`).\n",
     "-   `--text \"<string>\"`: The text string to compress.\n",
-    "-   `--file <path>`: Path to a text file for compression (e.g., `sample_data/moon_landing/full.txt`).\n",
+    "-   `<path_to_file_or_dir>`: (Positional) Path to the text file or directory to compress when `--text` is not used.\n",
     "-   `--budget <int>`: The target token budget.\n",
     "-   `--tokenizer <name>`: (Optional) Specify a tokenizer if the strategy shouldn't use its default.\n",
     "-   `--output <path>`: (Optional) Path to save the compressed output (e.g., as JSON). The compressed text is typically printed to the standard output if `--output` is not specified. Using `--output` is recommended for saving results, especially for larger inputs or when integrating into scripts.\n"
@@ -315,9 +315,11 @@
    "source": [
     "### 2.3 Talk Command (`talk`)\n",
     "\n",
-    "The `talk` command enables interactive chat with an LLM that uses a specified compression strategy to manage the conversation history. This is great for qualitatively evaluating how different strategies affect conversation flow and context retention.\n",
+    "The `talk` command enables interactive chat with an LLM. In some versions or configurations of `gist-memory`, a `--strategy` option might be available to manage live conversation history. However, in this particular fork, directly applying a compression strategy to the live, ongoing conversation history via `--strategy` might not be supported as described in original documentation. \n",
     "\n",
-    "Running a fully interactive `talk` session is not feasible within a static notebook cell. Instead, we'll show how to get help for the command and a conceptual example of its use."
+    "To use `talk` with a specific compression strategy applied to some initial context, it's recommended to first compress the relevant text using `gist-memory compress --output <output_file.json> ...` and then load this pre-compressed context using `gist-memory talk --memory <output_file.json> ...`. This approach is effective for providing the LLM with a condensed background from a document or previous interactions.\n",
+    "\n",
+    "Running a fully interactive `talk` session is not feasible within a static notebook cell. Instead, we'll show how to get help for the command and a conceptual example of its use, focusing on using pre-compressed memory."
    ],
    "metadata": {}
   },
@@ -337,18 +339,23 @@
     "\n",
     "You would typically run these in your terminal (from the repo root):\n",
     "\n",
-    "1.  **Talk with a strategy applied to the ongoing conversation history:**\n",
+    "1.  **Talk with pre-compressed initial context:**\n",
     "    ```bash\n",
-    "    gist-memory talk --strategy gist --chat-model tiny-gpt2 --budget 150\n",
+    "    # 1. First, create some initial context and compress it:\n",
+    "    echo \"This is some initial context for our conversation.\" > my_context.txt\n",
+    "    gist-memory compress --strategy gist my_context.txt --budget 100 --output initial_memory.json\n",
+    "    #\n",
+    "    # 2. Then, start the conversation using this pre-compressed memory:\n",
+    "    gist-memory talk --memory initial_memory.json --chat-model tiny-gpt2\n",
     "    ```\n",
-    "    This starts an interactive session where `tiny-gpt2` is the LLM, and the `gist` strategy compresses the conversation history to about 150 tokens before each LLM call.\n",
+    "    This multi-step process first compresses your desired context and then starts an interactive session with `tiny-gpt2` using that context.\n",
     "\n",
-    "2.  **Talk using a pre-compressed memory file:**\n",
+    "2.  **Talk using a pre-compressed memory file (e.g., a document):**\n",
     "    First, compress a document (using path relative to repo root):\n",
     "    ```bash\n",
-    "    gist-memory compress --strategy gist --file ./sample_data/moon_landing/full.txt --budget 200 --output moon_memory.json\n",
+    "    gist-memory compress --strategy gist ./sample_data/moon_landing/full.txt --budget 200 --output moon_memory.json\n",
     "    ```\n",
-    "    Then, start a conversation using this memory as initial context:\n",
+    "    Then, start a conversation using this memory as initial context, optionally with an initial message:\n",
     "    ```bash\n",
     "    gist-memory talk --memory moon_memory.json --chat-model tiny-gpt2 --message \"What were the main objectives?\"\n",
     "    ```\n",
@@ -363,9 +370,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This attempts a non-interactive query using the 'truncate' strategy with a specified chat model.\n",
+    "# This attempts a non-interactive query with a specified chat model.\n",
     "# The CLI might provide a single response or indicate it's for interactive use.\n",
-    "!gist-memory talk --strategy truncate --chat-model tiny-gpt2 --message \"What is the capital of France?\" --budget 50"
+    "!gist-memory talk --chat-model tiny-gpt2 --message \"What is the capital of France?\" --budget 50"
    ]
   },
   {
@@ -437,10 +444,10 @@
     "from gist_memory.compression import (\n",
     "    CompressionStrategy,\n",
     "    CompressedMemory,\n",
-    "    CompressionTrace,\n",
-    "    TextBlock\n",
+    "    CompressionTrace\n",
     "    # TokenBudget removed due to ImportError\n",
     ")\n",
+    "from gist_memory.schema import TextBlock\n",
     "\n",
     "from gist_memory.constants import ONBOARDING_DEMO_DIR \n",
     "from gist_memory.registry import register_compression_strategy \n",


### PR DESCRIPTION
Addresses issues in `examples/gist_memory_showcase.ipynb`:

- Corrected `gist-memory compress` commands to use positional arguments for file/directory paths instead of the non-existent `--file` option.
- Added `--text` option to `gist-memory compress` for clarity when providing a direct string.
- Corrected `gist-memory talk` command by removing the non-existent `--strategy` option.
- Updated markdown explanations for `compress` and `talk` commands to reflect their actual CLI usage and options.
- Fixed Python import error by changing `from gist_memory.compression import TextBlock` to `from gist_memory.schema import TextBlock`.

These changes ensure the notebook accurately demonstrates the CLI and Python API of the scottfalconer/gist-memory fork and resolves runtime errors.