### PR TITLE
Remove no-cache-dir from setup and add flake8

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 # Install Python dependencies for the repository and download spaCy model
 if [ -f requirements.txt ]; then
-    pip3 install --no-cache-dir -r requirements.txt
+    pip3 install -r requirements.txt
     # Install the package in editable mode so the CLI is available for demos
     pip3 install -e . --no-build-isolation
     # Download the spaCy model needed by the chunkers
@@ -22,10 +22,10 @@ if [ -f requirements.txt ]; then
 fi
 
 # Tools used by CI for linting and testing
-pip3 install --no-cache-dir flake8 pytest
+pip3 install flake8 pytest
 
 # CLI dependencies that may not be declared in requirements.txt
-pip3 install --no-cache-dir rich typer portalocker
+pip3 install rich typer portalocker
 
 # Pre-download the default local embedding model so tests work offline
 python3 - <<'PY'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ typer[all]>=0.16.0
 portalocker
 google-generativeai
 evaluate
+flake8


### PR DESCRIPTION
## Summary
- drop the `--no-cache-dir` flag in `.codex/setup.sh`
- install `flake8` via requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e6c23fac48329bd8dcfc481cd3d44