### PR TITLE
Remove brain references and use memory_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ This project requires **Python 3.11+**.
 
 Run `gist-memory --help` to see available commands and verify installation.
 
+You can also set a default location for the on-disk memory store with the
+`GIST_MEMORY_PATH` environment variable:
+
+```bash
+export GIST_MEMORY_PATH=~/my_memory
+```
+
 ## Core Workflow
 
 The `gist-memory` Command-Line Interface (CLI) is your primary tool for experimenting with different compression strategies and evaluating their effectiveness. Here are some examples of common operations:
@@ -232,7 +239,7 @@ Gist Memory is designed to support a wide variety of `CompressionStrategy` imple
 -   `docs/COMPRESSION_STRATEGIES.md`
 -   `docs/DEVELOPING_COMPRESSION_STRATEGIES.md`
 
-The `AgenticChunker` is an example of an advanced chunking mechanism. You can enable it during memory initialization (e.g., `gist-memory init brain --chunker agentic`) or programmatically within your custom strategy (e.g., `agent.chunker = AgenticChunker()`).
+The `AgenticChunker` is an example of an advanced chunking mechanism. You can enable it during memory initialization (e.g., `gist-memory init --memory-path my_memory --chunker agentic`) or programmatically within your custom strategy (e.g., `agent.chunker = AgenticChunker()`).
 
 ## Query Tips
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,7 +100,7 @@ quickly.
 ## CLI
 
 `gist-memory` is implemented using Typer and exposes subcommands for
-initialising a brain, inspecting stored prototypes and running
+initialising a memory store, inspecting stored prototypes and running
 experiments. The CLI is the primary interface, and a Colab notebook will
 provide a graphical option in the future.
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1,9 +1,9 @@
 # Storage Format
 
-This document describes how a Gist Memory "brain" is stored on disk.  A brain is a directory containing several JSON and NPY files along with a small YAML metadata file.  The layout is intentionally simple so that the contents can be inspected or backed up with regular tools.
+This document describes how a Gist Memory memory store is kept on disk.  A memory store is a directory containing several JSON and NPY files along with a small YAML metadata file.  The layout is intentionally simple so that the contents can be inspected or backed up with regular tools.
 
 ```
-brain/
+memory/
 ├── meta.yaml
 ├── belief_prototypes.json
 ├── prototype_vectors.npy
@@ -27,7 +27,7 @@ updated_at: "2024-01-01T00:00:00Z"
 
 The `version` field defines the storage schema.  The current code understands
 version `1`.  Should a future release change the file layout, this value will be
-incremented and migration logic will be added.  Tools loading a brain should
+incremented and migration logic will be added.  Tools loading a memory store should
 check the `version` field before attempting to read the other files.
 
 ## Prototype files

--- a/gist_memory/__init__.py
+++ b/gist_memory/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "SentenceWindowChunker",
     "FixedSizeChunker",
     "AgenticChunker",
-    "DEFAULT_BRAIN_PATH",
+    "DEFAULT_MEMORY_PATH",
     "LocalChatModel",
     "render_five_w_template",
     "MemoryCueRenderer",
@@ -63,7 +63,7 @@ _lazy_map = {
     "SentenceWindowChunker": "gist_memory.chunker",
     "FixedSizeChunker": "gist_memory.chunker",
     "AgenticChunker": "gist_memory.chunker",
-    "DEFAULT_BRAIN_PATH": "gist_memory.config",
+    "DEFAULT_MEMORY_PATH": "gist_memory.config",
     "LocalChatModel": "gist_memory.local_llm",
     "render_five_w_template": "gist_memory.prototype.canonical",
     "MemoryCueRenderer": "gist_memory.prototype.memory_cues",
@@ -105,4 +105,4 @@ def __dir__() -> list[str]:  # pragma: no cover - for completeness
     return sorted(list(globals().keys()) + list(_lazy_map.keys()))
 
 
-__version__ = "0.4.0"
+__version__ = "1.0.0"

--- a/gist_memory/config.py
+++ b/gist_memory/config.py
@@ -1,5 +1,9 @@
 """Shared configuration constants."""
 
-DEFAULT_BRAIN_PATH = "brain"
+import os
 
-__all__ = ["DEFAULT_BRAIN_PATH"]
+# Default location for on-disk memory store. Can be overridden with the
+# ``GIST_MEMORY_PATH`` environment variable.
+DEFAULT_MEMORY_PATH = os.environ.get("GIST_MEMORY_PATH", "memory")
+
+__all__ = ["DEFAULT_MEMORY_PATH"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gist-memory"
-version = "0.1.0"
+version = "1.0.0"
 description = "Prototype implementation of the Gist Memory Agent"
 authors = [{name = "Scott Falconer", email = "scottfalconer@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- rename `DEFAULT_BRAIN_PATH` to `DEFAULT_MEMORY_PATH`
- require `--memory-path` across CLI commands
- add `GIST_MEMORY_PATH` env var for default memory directory
- bump version to 1.0.0
- update docs and README for new terminology
- adjust tests for new flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e73945b6083299d443d5c267232d4