### PR TITLE
Refactor: CLI structure and global config - Phases 1 & 2 (partial)

### DIFF
--- a/gist_memory/cli.py
+++ b/gist_memory/cli.py
@@ -3,13 +3,13 @@ import shutil
 import os
 import yaml
 from pathlib import Path
-from typing import Optional, Any  # List removed
+from typing import Optional, Any
 import logging
-import time  # Moved from _process_string_compression
-from dataclasses import asdict  # Moved from _process_string_compression
-import sys  # Moved from local imports
-from tqdm import tqdm  # Moved from download_model and download_chat_model
-import runpy  # Moved from optimize_experiment
+import time
+from dataclasses import asdict
+import sys
+from tqdm import tqdm
+import runpy
 
 import typer
 import portalocker
@@ -23,23 +23,24 @@ from .logging_utils import configure_logging
 
 from .agent import Agent
 from .json_npy_store import JsonNpyVectorStore
-from . import local_llm  # import module so tests can patch LocalChatModel
-from .active_memory_manager import ActiveMemoryManager  # Moved from talk
+from . import local_llm
+from .active_memory_manager import ActiveMemoryManager
 from .registry import (
     _VALIDATION_METRIC_REGISTRY,
     get_validation_metric_class,
-)  # Moved from metric_list, evaluate_compression, evaluate_llm_response
-from . import llm_providers  # import module so tests can patch providers
+)
+from . import llm_providers
 from .model_utils import (
-    download_embedding_model,
-    download_chat_model as _download_chat_model,
-)  # Moved from download_model, download_chat_model
+    download_embedding_model as util_download_embedding_model, # Renamed to avoid clash
+    download_chat_model as util_download_chat_model, # Renamed to avoid clash
+)
 from .embedding_pipeline import (
     get_embedding_dim,
     EmbeddingDimensionMismatchError,
 )
 from .utils import load_agent
-from .config import DEFAULT_MEMORY_PATH
+from gist_memory.config import Config
+
 from .compression import (
     available_strategies,
     get_compression_strategy,
@@ -58,1249 +59,409 @@ from .response_experiment import ResponseExperimentConfig, run_response_experime
 from .experiment_runner import (
     ExperimentConfig,
     run_experiment,
-)  # Moved from run_experiment_cmd
+)
 
 app = typer.Typer(
     help="Gist Memory: A CLI for managing and interacting with a memory agent that uses advanced compression strategies to store and retrieve information. Primary actions like ingest, query, and talk are available as subcommands, along with advanced features for managing strategies, metrics, and experiments."
 )
 console = Console()
-# VERBOSE = False # Unused global variable
 
+# --- New Command Groups ---
+agent_app = typer.Typer(help="Manage agents: initialize, inspect statistics, validate, and clear.")
+config_app = typer.Typer(help="Manage Gist Memory configuration settings.")
+dev_app = typer.Typer(help="Developer tools for testing, evaluation, and package management.")
+
+# --- Add New Command Groups to Main App ---
+app.add_typer(agent_app, name="agent")
+app.add_typer(config_app, name="config")
+app.add_typer(dev_app, name="dev")
 
 def version_callback(value: bool):
     if value:
         typer.echo(f"Gist Memory version: {__version__}")
         raise typer.Exit()
 
-
 @app.callback(invoke_without_command=False)
 def main(
     ctx: typer.Context,
-    log_file: Optional[Path] = typer.Option(
-        None, "--log-file", help="Write debug logs to this file"
-    ),
-    verbose: bool = typer.Option(False, "--verbose", help="Enable debug logging"),
-    version: Optional[bool] = typer.Option(
-        None,
-        "-v",
-        "--version",
-        callback=version_callback,
-        is_eager=True,
-        help="Show the version and exit.",
-    ),
+    log_file: Optional[Path] = typer.Option(None, "--log-file", help="Write debug logs to this file"),
+    verbose: bool = typer.Option(False, "--verbose", "-V", help="Enable debug logging"),
+    memory_path: Optional[str] = typer.Option(None, "--memory-path", "-m", help="Memory store directory (overrides config/env)"),
+    model_id: Optional[str] = typer.Option(None, "--model-id", help="Default model ID for LLM interactions (overrides config/env)"),
+    strategy_id: Optional[str] = typer.Option(None, "--strategy-id", help="Default compression strategy ID (overrides config/env)"),
+    version: Optional[bool] = typer.Option(None, "-v", "--version", callback=version_callback, is_eager=True, help="Show the version and exit."),
 ) -> None:
-    """Configure logging before executing commands."""
-    if log_file:
-        level = logging.DEBUG if verbose else logging.INFO
-        configure_logging(log_file, level)
-    elif verbose:
-        logging.basicConfig(level=logging.DEBUG)
-    # global VERBOSE # Unused global variable
-    # VERBOSE = verbose # Unused global variable
-    load_plugins()
-    ctx.obj = {"verbose": verbose}
+    config = Config()
+    config.validate()
 
+    resolved_log_file = log_file
+    resolved_verbose = verbose
+
+    if resolved_log_file:
+        level = logging.DEBUG if resolved_verbose else logging.INFO
+        configure_logging(resolved_log_file, level)
+    elif resolved_verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    resolved_memory_path = memory_path if memory_path is not None else config.get("gist_memory_path")
+    resolved_model_id = model_id if model_id is not None else config.get("default_model_id")
+    resolved_strategy_id = strategy_id if strategy_id is not None else config.get("default_strategy_id")
+
+    if resolved_memory_path:
+        resolved_memory_path = str(Path(resolved_memory_path).expanduser())
+
+    if not resolved_memory_path and not any(cmd_name in ctx.invoked_subcommand for cmd_name in ["config", "dev"]): # Skip prompt for config and dev commands
+        is_interactive = sys.stdin.isatty()
+        prompt_default_path = config.get("gist_memory_path")
+
+        if is_interactive:
+            typer.secho("The Gist Memory path is not set.", fg=typer.colors.YELLOW)
+            new_path_input = typer.prompt("Please enter the path for Gist Memory storage", default=str(Path(prompt_default_path).expanduser()) if prompt_default_path else None)
+            if new_path_input:
+                resolved_memory_path = str(Path(new_path_input).expanduser())
+                typer.secho(f"Using memory path: {resolved_memory_path}", fg=typer.colors.GREEN)
+                typer.echo(f"To set this path permanently, run: gist-memory config set gist_memory_path \"{resolved_memory_path}\"")
+            else:
+                typer.secho("Memory path is required to proceed.", fg=typer.colors.RED, err=True)
+                raise typer.Exit(code=1)
+        elif ctx.invoked_subcommand not in ["ingest", "query", "summarize", "agent"]: # Only error if essential commands are called non-interactively without path
+            typer.secho("Error: Gist Memory path is not set.", fg=typer.colors.RED, err=True)
+            typer.secho("Please set it using the --memory-path option, the GIST_MEMORY_PATH environment variable, or in a config file (~/.config/gist_memory/config.yaml or .gmconfig.yaml).", err=True)
+            raise typer.Exit(code=1)
+
+
+    load_plugins()
+
+    if ctx.obj is None: ctx.obj = {}
+    ctx.obj.update({
+        "verbose": resolved_verbose, "log_file": resolved_log_file,
+        "gist_memory_path": resolved_memory_path, "default_model_id": resolved_model_id,
+        "default_strategy_id": resolved_strategy_id, "config": config,
+    })
 
 class PersistenceLock:
-    def __init__(self, path: Path) -> None:
-        self.file = (path / ".lock").open("a+")
-
-    def __enter__(self):
-        portalocker.lock(self.file, portalocker.LockFlags.EXCLUSIVE)
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        portalocker.unlock(self.file)
-        self.file.close()
-
+    def __init__(self, path: Path) -> None: self.file = (path / ".lock").open("a+")
+    def __enter__(self): portalocker.lock(self.file, portalocker.LockFlags.EXCLUSIVE); return self
+    def __exit__(self, exc_type, exc, tb): portalocker.unlock(self.file); self.file.close()
 
 def _corrupt_exit(path: Path, exc: Exception) -> None:
     typer.echo(f"Error: Brain data is corrupted. {exc}", err=True)
-    typer.echo(
-        f"Try running gist-memory validate {path} for more details or restore from a backup.",
-        err=True,
-    )
+    typer.echo(f"Try running gist-memory validate {path} for more details or restore from a backup.", err=True)
     raise typer.Exit(code=1)
 
-
 def _load_agent(path: Path) -> Agent:
-    try:
-        return load_agent(path)
-    except Exception as exc:
-        _corrupt_exit(path, exc)
+    try: return load_agent(path)
+    except Exception as exc: _corrupt_exit(path, exc)
 
+# --- Agent Commands ---
+@agent_app.command("init")
+def init(target_directory: Path = typer.Argument(..., help="Target directory for the new agent. This will be created if it doesn't exist.", resolve_path=True ), *, ctx: typer.Context, name: str = typer.Option("default", help="Name of the agent"), model_name: str = typer.Option("all-MiniLM-L6-v2", help="Embedding model name"), tau: float = 0.8, alpha: float = typer.Option(0.1, help="Alpha parameter for the agent"), chunker: str = typer.Option("sentence_window", help="Chunking strategy for the agent")) -> None:
+    path = target_directory.expanduser()
+    if path.exists() and any(path.iterdir()): typer.secho("Directory already exists and is not empty", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    if not 0.5 <= tau <= 0.95: typer.secho("Error: --tau must be between 0.5 and 0.95.", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    try: dim = get_embedding_dim()
+    except RuntimeError as exc: typer.echo(str(exc), err=True); raise typer.Exit(code=1)
+    store = JsonNpyVectorStore(path=str(path), embedding_model=model_name, embedding_dim=dim)
+    store.meta.update({"agent_name": name, "tau": tau, "alpha": alpha, "chunker": chunker})
+    store.save(); typer.echo(f"Initialized agent at {path}")
 
-@app.command()
-def init(
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-    *,
-    name: str = "default",
-    model_name: str = "all-MiniLM-L6-v2",
-    tau: float = 0.8,
-    alpha: float = 0.1,
-    chunker: str = "sentence_window",
-) -> None:
-    """
-    Creates and initializes a new agent data store at the specified directory.
-
-    This command sets up the necessary file structure and metadata for a new
-    Gist Memory agent. You can specify parameters like the agent name,
-    embedding model, similarity threshold (tau), and chunking strategy.
-
-    Usage Example:
-        gist-memory init --memory-path path/to/my_agent --model-name sentence-transformers/all-mpnet-base-v2 --tau 0.8
-    """
-    path = Path(memory_path)
-    if path.exists() and any(path.iterdir()):
-        typer.secho(
-            "Directory already exists and is not empty",
-            err=True,
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(code=1)
-    if not 0.5 <= tau <= 0.95:
-        typer.secho(
-            "Error: --tau must be between 0.5 and 0.95.",
-            err=True,
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(code=1)
-    try:
-        dim = get_embedding_dim()
-    except RuntimeError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1)
-    store = JsonNpyVectorStore(
-        path=str(path), embedding_model=model_name, embedding_dim=dim
-    )
-    store.meta.update(
-        {
-            "agent_name": name,
-            "tau": tau,
-            "alpha": alpha,
-            "chunker": chunker,
-        }
-    )
-    store.save()
-    typer.echo(f"Initialized agent at {memory_path}")
-
-
-strategy_app = typer.Typer(
-    help="Manage and inspect Long-Term Memory (LTM) compression strategies."
-)
-app.add_typer(strategy_app, name="strategy")
-
-metric_app = typer.Typer(
-    help="Manage and inspect validation metrics for compression and LLM responses."
-)
-app.add_typer(metric_app, name="metric")
-
-package_app = typer.Typer(help="Manage custom strategy packages.")
-app.add_typer(package_app, name="package")
-
-experiment_app = typer.Typer(
-    help="Run various experiments for ingestion, responses, and hyperparameter optimization."
-)
-app.add_typer(experiment_app, name="experiment")
-
-trace_app = typer.Typer(help="Inspect and analyze compression traces.")
-app.add_typer(trace_app, name="trace")
-load_cli_plugins(app)
-
-
-@metric_app.command("list")
-def metric_list() -> None:
-    """
-    Lists all available validation metric IDs that can be used with
-    `evaluate-compression` and `evaluate-llm-response` commands.
-
-    Usage Example:
-        gist-memory metric list
-    """
-    # from .registry import _VALIDATION_METRIC_REGISTRY # Moved to top
-
-    for mid in sorted(_VALIDATION_METRIC_REGISTRY):
-        typer.echo(mid)
-
-
-@strategy_app.command("inspect")
-def strategy_inspect(
-    strategy_name: str,
-    *,
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-    list_prototypes: bool = typer.Option(
-        False, "--list-prototypes", help="List prototypes for the strategy"
-    ),
-) -> None:
-    """
-    Inspect the details of a compression strategy, particularly its prototypes.
-
-    This command allows you to inspect the details of a compression strategy.
-    For the 'prototype' strategy, you can list the learned prototypes, which are
-    representative summaries of related memories within the specified agent.
-
-    Usage Example:
-        gist-memory strategy inspect prototype --memory-path path/to/agent --list-prototypes
-    """
-
-    if strategy_name != "prototype":
-        typer.echo(f"Unknown strategy: {strategy_name}", err=True)
-        raise typer.Exit(code=1)
-
-    path = Path(memory_path)
-    if not path.exists():
-        typer.secho(
-            f"Error: Memory path '{path}' not found or is invalid.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    agent = _load_agent(path)
-
-    if list_prototypes:
-        protos = agent.get_prototypes_view()
-        table = Table("id", "strength", "confidence", "summary", title="Beliefs")
-        for p in protos:
-            table.add_row(
-                p["id"],
-                f"{p['strength']:.2f}",
-                f"{p['confidence']:.2f}",
-                p["summary"][:60],
-            )
-        console.print(table)
-
-
-@strategy_app.command("list")
-def strategy_list() -> None:
-    """
-    Lists all available Long-Term Memory (LTM) compression strategies
-    along with their metadata such as display name, version, and source.
-
-    Usage Example:
-        gist-memory strategy list
-    """
-    load_plugins()
-    table = Table("Strategy ID", "Display Name", "Version", "Source", "Status")
-    meta = all_strategy_metadata()
-    for sid in available_strategies():
-        info = meta.get(sid, {})
-        status = ""
-        if info.get("overrides"):
-            status = f"Overrides {info['overrides']}"
-        table.add_row(
-            sid,
-            info.get("display_name", sid) or sid,
-            info.get("version", "N/A") or "N/A",
-            info.get("source", "built-in") or "built-in",
-            status,
-        )
-    console.print(table)
-
-
-
-
-@app.command()
-def stats(
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-    json_output: bool = typer.Option(False, "--json", help="JSON output"),
-) -> None:
-    """
-    Show statistics about the agent's data store.
-
-    This command displays various statistics about the specified agent's memory,
-    such as the number of prototypes and memories.
-    Use the --json option to dump these statistics in a machine-readable JSON format,
-    which can be useful for scripting or further analysis.
-
-    Usage Example (dump to JSON and redirect to a file):
-        gist-memory stats --memory-path path/to/agent --json > agent_stats.json
-    """
-    path = Path(memory_path)
-    if not path.exists():
-        typer.secho(
-            f"Error: Memory path '{path}' not found or is invalid.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    agent = _load_agent(path)
-    data = agent.get_statistics()
-    logging.debug("Collected statistics: %s", data)
-    if json_output:
-        typer.echo(json.dumps(data))
+@agent_app.command("stats")
+def stats(ctx: typer.Context, memory_path_arg: Optional[str] = typer.Option(None, "--memory-path", "-m", help="Memory store directory (if different from global --memory-path)"), json_output: bool = typer.Option(False, "--json", help="JSON output")) -> None:
+    final_memory_path_str = memory_path_arg if memory_path_arg is not None else ctx.obj.get("gist_memory_path")
+    if final_memory_path_str is None: typer.secho("Critical Error: Memory path could not be resolved for stats.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    path = Path(final_memory_path_str)
+    if not path.exists(): typer.secho(f"Error: Memory path '{path}' not found or is invalid.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    agent = _load_agent(path); data = agent.get_statistics(); logging.debug("Collected statistics: %s", data)
+    if json_output: typer.echo(json.dumps(data))
     else:
-        for k, v in data.items():
-            typer.echo(f"{k}: {v}")
+        for k, v in data.items(): typer.echo(f"{k}: {v}")
 
+@agent_app.command("validate")
+def validate_agent_storage(ctx: typer.Context, memory_path_arg: Optional[str] = typer.Option(None, "--memory-path", "-m", help="Memory store directory (if different from global --memory-path)")) -> None:
+    final_memory_path_str = memory_path_arg if memory_path_arg is not None else ctx.obj.get("gist_memory_path")
+    if final_memory_path_str is None: typer.secho("Critical Error: Memory path could not be resolved for validate.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    path = Path(final_memory_path_str)
+    if not path.exists(): typer.secho(f"Error: Memory path '{path}' not found or is invalid.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    try: JsonNpyVectorStore(path=str(path))
+    except EmbeddingDimensionMismatchError as exc: typer.secho(f"Embedding dimension mismatch: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    except Exception as exc: typer.secho(f"Error loading agent: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    typer.echo("Store is valid")
 
-@app.command()
-def talk(
-    *,
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-    message: str = typer.Option(..., help="Message to send"),
-    model_name: str = typer.Option("tiny-gpt2", help="Local chat model"),
-    compression_strategy: Optional[str] = typer.Option(
-        None,
-        "--compression",
-        help="Compression strategy",
-        case_sensitive=False,
-    ),
-    show_prompt_tokens: bool = typer.Option(
-        False,
-        "--show-prompt-tokens",
-        help="Display token count of the prompt sent to the LLM",
-    ),
-) -> None:
-    """
-    Interact with the memory agent by sending it a message.
+@agent_app.command("clear")
+def clear(ctx: typer.Context, memory_path_arg: Optional[str] = typer.Option(None, "--memory-path", "-m", help="Memory store directory (if different from global --memory-path)"), force: bool = typer.Option(False, "--force", "-f", help="Force deletion without confirmation"), dry_run: bool = typer.Option(False, "--dry-run", help="Do not delete files")) -> None:
+    final_memory_path_str = memory_path_arg if memory_path_arg is not None else ctx.obj.get("gist_memory_path")
+    if final_memory_path_str is None: typer.secho("Critical Error: Memory path could not be resolved for clear.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    path = Path(final_memory_path_str)
+    if not path.exists(): typer.secho(f"Error: Memory path '{path}' not found or is invalid.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    if dry_run: store = JsonNpyVectorStore(path=str(path)); typer.echo(f"Would delete {len(store.prototypes)} prototypes and {len(store.memories)} memories."); return
+    if not force:
+        if not typer.confirm(f"Delete {path}?", abort=True): return
+    if path.exists(): shutil.rmtree(path); typer.echo(f"Deleted {path}")
+    else: typer.secho("Directory not found", err=True, fg=typer.colors.RED)
 
-    This command allows you to have a conversation with the agent. The agent uses its
-    stored knowledge, organized into prototypes, to understand and respond to your messages.
+# --- Top-Level Commands ---
+@app.command("ingest")
+def ingest_placeholder(ctx: typer.Context, text_or_path: str = typer.Argument(..., help="Text content or path to a file/directory to ingest.")):
+    typer.echo(f"Placeholder for ingest command. Input: {text_or_path}"); typer.echo(f"Using memory path: {ctx.obj.get('gist_memory_path')}")
 
-    Prototypes are representative summaries of related memories. When you talk to the
-    agent, it uses these prototypes to retrieve relevant information to formulate a response.
-
-    Usage Example:
-        gist-memory talk --memory-path path/to/agent --message "What do you know about topic X?"
-    """
-
-    path = Path(memory_path)
-    if not path.exists():
-        typer.secho(
-            f"Error: Memory path '{path}' not found or is invalid.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
+@app.command("query", help="Queries the agent with the provided text and returns a response.")
+def query(ctx: typer.Context, query_text: str = typer.Argument(..., help="Query to ask the agent."), show_prompt_tokens: bool = typer.Option(False, "--show-prompt-tokens", help="Display token count of the prompt sent to the LLM")) -> None:
+    final_memory_path_str = ctx.obj.get("gist_memory_path")
+    if final_memory_path_str is None: typer.secho("Critical Error: Memory path could not be resolved for query.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    path = Path(final_memory_path_str)
+    if not path.exists(): typer.secho(f"Error: Memory path '{path}' not found or is invalid.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
     with PersistenceLock(path):
-        agent = _load_agent(path)
-
-        # from .local_llm import LocalChatModel # Moved to top
-
-        try:
-            agent._chat_model = local_llm.LocalChatModel(model_name=model_name)
-            agent._chat_model.load_model()
-        except RuntimeError as exc:
-            typer.echo(str(exc), err=True)
-            raise typer.Exit(code=1)
-
-        # from .active_memory_manager import ActiveMemoryManager # Moved to top
-
-        mgr = ActiveMemoryManager()
-        comp = None
-        if compression_strategy:  # Simplified condition
-            try:
-                comp_cls = get_compression_strategy(compression_strategy)
-                comp = comp_cls()
-            except KeyError:
-                typer.secho(
-                    f"Unknown compression strategy '{compression_strategy}'",
-                    err=True,
-                    fg=typer.colors.RED,
-                )
-                raise typer.Exit(code=1)
-
-        try:
-            result = agent.receive_channel_message(
-                "cli", message, mgr, compression=comp
-            )
-        except TypeError:
-            result = agent.receive_channel_message("cli", message, mgr)
+        agent = _load_agent(path); final_model_name = ctx.obj.get("default_model_id"); final_compression_strategy = ctx.obj.get("default_strategy_id")
+        if final_model_name is None: typer.secho("Error: Model ID not specified globally or via config.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+        try: agent._chat_model = local_llm.LocalChatModel(model_name=final_model_name); agent._chat_model.load_model()
+        except RuntimeError as exc: typer.echo(str(exc), err=True); raise typer.Exit(code=1)
+        mgr = ActiveMemoryManager(); comp = None
+        if final_compression_strategy and final_compression_strategy.lower() != "none":
+            try: comp_cls = get_compression_strategy(final_compression_strategy); comp = comp_cls()
+            except KeyError: typer.secho(f"Unknown compression strategy '{final_compression_strategy}' (from global config).", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+        try: result = agent.receive_channel_message("cli", query_text, mgr, compression=comp)
+        except TypeError: result = agent.receive_channel_message("cli", query_text, mgr)
         reply = result.get("reply")
-        if reply:
-            typer.echo(reply)
-        if show_prompt_tokens and result.get("prompt_tokens") is not None:
-            typer.echo(f"Prompt tokens: {result['prompt_tokens']}")
+        if reply: typer.echo(reply)
+        if show_prompt_tokens and result.get("prompt_tokens") is not None: typer.echo(f"Prompt tokens: {result['prompt_tokens']}")
 
-    return
-
-
-def _process_string_compression(
-    text_content: str,
-    strategy_id: str,
-    budget: int,
-    output_file: Optional[Path],
-    trace_file: Optional[Path],
-    verbose_stats: bool,
-    tokenizer: Any,
-) -> None:
-    """Compress a string and handle output."""
-    try:
-        strat_cls = get_compression_strategy(strategy_id)
-    except KeyError:
-        typer.secho(
-            f"Unknown compression strategy '{strategy_id}'. Available: {', '.join(available_strategies())}",
-            err=True,
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(code=1)
-
-    strat = strat_cls()
-    # import time # Moved to top
-
-    start = time.time()
-    result = strat.compress(text_content, budget, tokenizer=tokenizer)
-    if isinstance(result, tuple):
-        compressed, trace = result
+@app.command("summarize", help="Summarizes the given text content or file/directory using a specified strategy.")
+def summarize(ctx: typer.Context, input_source: str = typer.Argument(..., help="Input text directly or path to a file or directory to summarize"), *, strategy_arg: Optional[str] = typer.Option(None, "--strategy", "-s", help="Compression strategy (overrides global default_strategy_id)"), output_path: Optional[Path] = typer.Option(None, "-o", "--output", resolve_path=True, help=("Path to write compressed output. For directories, this specifies the root output directory.")), output_trace: Optional[Path] = typer.Option(None, "--output-trace", resolve_path=True, help="Write CompressionTrace JSON to this file"), recursive: bool = typer.Option(False, "-r", "--recursive", help="Process directories recursively"), pattern: str = typer.Option("*.txt", "-p", "--pattern", help="File glob pattern when reading from a directory"), budget: int = typer.Option(..., help="Token budget"), verbose_stats: bool = typer.Option(False, "--verbose-stats", help="Show token counts and processing time")) -> None:
+    final_strategy_id = strategy_arg if strategy_arg is not None else ctx.obj.get("default_strategy_id")
+    if not final_strategy_id: typer.secho("Error: Compression strategy not specified via --strategy or global/config default_strategy_id.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    try: import tiktoken; enc = tiktoken.get_encoding("gpt2"); tokenizer = lambda text, **k: {"input_ids": enc.encode(text)}
+    except Exception: tokenizer = lambda t, **k: t.split()
+    source_as_path = Path(input_source)
+    if source_as_path.is_file():
+        if recursive or pattern != "*.txt":
+            if recursive: typer.secho("--recursive ignored for file input", fg=typer.colors.YELLOW)
+            if pattern != "*.txt": typer.secho("--pattern ignored for file input", fg=typer.colors.YELLOW)
+        _process_file_compression(source_as_path, final_strategy_id, budget, output_path, verbose_stats, tokenizer, output_trace)
+    elif source_as_path.is_dir():
+        if "**" in pattern and not recursive: typer.secho("Pattern includes '**' but --recursive not set; matching may miss subdirectories", fg=typer.colors.YELLOW)
+        _process_directory_compression(source_as_path, final_strategy_id, budget, output_path, recursive, pattern, verbose_stats, tokenizer, output_trace)
     else:
-        compressed, trace = result, None
+        if recursive or pattern != "*.txt":
+            if recursive: typer.secho("--recursive ignored for string input", fg=typer.colors.YELLOW)
+            if pattern != "*.txt": typer.secho("--pattern ignored for string input", fg=typer.colors.YELLOW)
+        _process_string_compression(input_source, final_strategy_id, budget, output_path, output_trace, verbose_stats, tokenizer)
+
+# --- Helper functions for summarize (formerly compress_text) ---
+def _process_string_compression(text_content: str, strategy_id: str, budget: int, output_file: Optional[Path], trace_file: Optional[Path], verbose_stats: bool, tokenizer: Any) -> None:
+    try: strat_cls = get_compression_strategy(strategy_id)
+    except KeyError: typer.secho(f"Unknown compression strategy '{strategy_id}'. Available: {', '.join(available_strategies())}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    strat = strat_cls(); start = time.time(); result = strat.compress(text_content, budget, tokenizer=tokenizer)
+    if isinstance(result, tuple): compressed, trace = result
+    else: compressed, trace = result, None
     elapsed = (time.time() - start) * 1000
-    if trace and trace.processing_ms is None:
-        trace.processing_ms = elapsed
+    if trace and trace.processing_ms is None: trace.processing_ms = elapsed
     if verbose_stats:
-        orig_tokens = token_count(tokenizer, text_content)
-        comp_tokens = token_count(tokenizer, compressed.text)
-        typer.echo(
-            f"Original tokens: {orig_tokens}\nCompressed tokens: {comp_tokens}\nTime ms: {elapsed:.1f}"
-        )
+        orig_tokens = token_count(tokenizer, text_content); comp_tokens = token_count(tokenizer, compressed.text)
+        typer.echo(f"Original tokens: {orig_tokens}\nCompressed tokens: {comp_tokens}\nTime ms: {elapsed:.1f}")
     if output_file:
-        try:
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_text(compressed.text)
-        except (IOError, OSError, PermissionError) as exc:
-            typer.secho(
-                f"Error writing {output_file}: {exc}", err=True, fg=typer.colors.RED
-            )
-            raise typer.Exit(code=1)
+        try: output_file.parent.mkdir(parents=True, exist_ok=True); output_file.write_text(compressed.text)
+        except (IOError, OSError, PermissionError) as exc: typer.secho(f"Error writing {output_file}: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
         typer.echo(f"Saved compressed output to {output_file}")
-    else:
-        typer.echo(compressed.text)
-
+    else: typer.echo(compressed.text)
     if trace_file and trace:
-        # from dataclasses import asdict # Moved to top
+        try: trace_file.parent.mkdir(parents=True, exist_ok=True); trace_file.write_text(json.dumps(asdict(trace)))
+        except (IOError, OSError, PermissionError) as exc: typer.secho(f"Error writing {trace_file}: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
 
-        try:
-            trace_file.parent.mkdir(parents=True, exist_ok=True)
-            trace_file.write_text(
-                json.dumps(asdict(trace))
-            )  # json is imported globally
-        except (IOError, OSError, PermissionError) as exc:
-            typer.secho(
-                f"Error writing {trace_file}: {exc}", err=True, fg=typer.colors.RED
-            )
-            raise typer.Exit(code=1)
+def _process_file_compression(file_path: Path, strategy_id: str, budget: int, output_file: Optional[Path], verbose_stats: bool, tokenizer: Any, trace_file: Optional[Path]) -> None:
+    if not file_path.exists() or not file_path.is_file(): typer.secho(f"File not found: {file_path}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    try: text_content = file_path.read_text()
+    except (IOError, OSError, PermissionError) as exc: typer.secho(f"Error reading {file_path}: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    _process_string_compression(text_content, strategy_id, budget, output_file, trace_file, verbose_stats, tokenizer)
 
-
-def _process_file_compression(
-    file_path: Path,
-    strategy_id: str,
-    budget: int,
-    output_file: Optional[Path],
-    verbose_stats: bool,
-    tokenizer: Any,
-    trace_file: Optional[Path],
-) -> None:
-    """Compress text loaded from ``file_path``."""
-    if not file_path.exists() or not file_path.is_file():
-        typer.secho(f"File not found: {file_path}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-    try:
-        text_content = file_path.read_text()
-    except (IOError, OSError, PermissionError) as exc:
-        typer.secho(f"Error reading {file_path}: {exc}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-    _process_string_compression(
-        text_content,
-        strategy_id,
-        budget,
-        output_file,
-        trace_file,
-        verbose_stats,
-        tokenizer,
-    )
-
-
-def _process_directory_compression(
-    dir_path: Path,
-    strategy_id: str,
-    budget: int,
-    output_dir_param: Optional[Path],
-    recursive: bool,
-    pattern: str,
-    verbose_stats: bool,
-    tokenizer: Any,
-    trace_file: Optional[Path],
-) -> None:
-    """Compress all files in ``dir_path`` matching ``pattern``."""
-    if not dir_path.exists() or not dir_path.is_dir():
-        typer.secho(f"Directory not found: {dir_path}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
+def _process_directory_compression(dir_path: Path, strategy_id: str, budget: int, output_dir_param: Optional[Path], recursive: bool, pattern: str, verbose_stats: bool, tokenizer: Any, trace_file: Optional[Path]) -> None:
+    if not dir_path.exists() or not dir_path.is_dir(): typer.secho(f"Directory not found: {dir_path}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     files = list(dir_path.rglob(pattern) if recursive else dir_path.glob(pattern))
-    if not files:
-        typer.echo("No matching files found.")
-        return
-    if trace_file is not None:
-        typer.secho(
-            "--output-trace ignored for directory input", fg=typer.colors.YELLOW
-        )
-        trace_file = None
-
+    if not files: typer.echo("No matching files found."); return
+    if trace_file is not None: typer.secho("--output-trace ignored for directory input", fg=typer.colors.YELLOW); trace_file = None
     count = 0
     for input_file in files:
         typer.echo(f"Processing {input_file}...")
         if output_dir_param:
-            try:
-                output_dir_param.mkdir(parents=True, exist_ok=True)
-            except (IOError, OSError, PermissionError) as exc:
-                typer.secho(
-                    f"Error creating {output_dir_param}: {exc}",
-                    err=True,
-                    fg=typer.colors.RED,
-                )
-                raise typer.Exit(code=1)
-            rel = input_file.relative_to(dir_path)
-            out_path = output_dir_param / rel
-            out_path.parent.mkdir(parents=True, exist_ok=True)
-        else:
-            out_path = input_file.with_name(
-                f"{input_file.stem}_compressed{input_file.suffix}"
-            )
+            try: output_dir_param.mkdir(parents=True, exist_ok=True)
+            except (IOError, OSError, PermissionError) as exc: typer.secho(f"Error creating {output_dir_param}: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+            rel = input_file.relative_to(dir_path); out_path = output_dir_param / rel; out_path.parent.mkdir(parents=True, exist_ok=True)
+        else: out_path = input_file.with_name(f"{input_file.stem}_compressed{input_file.suffix}")
+        _process_file_compression(input_file, strategy_id, budget, out_path, verbose_stats, tokenizer, None); count += 1
+    if verbose_stats: typer.echo(f"Processed {count} files.")
 
-        _process_file_compression(
-            input_file, strategy_id, budget, out_path, verbose_stats, tokenizer, None
-        )
-        count += 1
+# --- Dev App Commands ---
+@dev_app.command("list-metrics")
+def list_metrics() -> None:
+    for mid in sorted(_VALIDATION_METRIC_REGISTRY): typer.echo(mid)
 
-    if verbose_stats:
-        typer.echo(f"Processed {count} files.")
+@dev_app.command("list-strategies")
+def list_strategies() -> None:
+    load_plugins()
+    table = Table("Strategy ID", "Display Name", "Version", "Source", "Status")
+    meta = all_strategy_metadata()
+    for sid in available_strategies():
+        info = meta.get(sid, {}); status = "";
+        if info.get("overrides"): status = f"Overrides {info['overrides']}"
+        table.add_row(sid, info.get("display_name", sid) or sid, info.get("version", "N/A") or "N/A", info.get("source", "built-in") or "built-in", status)
+    console.print(table)
 
+@dev_app.command("inspect-strategy")
+def inspect_strategy(strategy_name: str, *, ctx: typer.Context, memory_path_arg: Optional[str] = typer.Option(None, "--memory-path", "-m", help="Memory store directory (if different from global --memory-path)"), list_prototypes: bool = typer.Option(False, "--list-prototypes", help="List prototypes for the strategy")) -> None:
+    if strategy_name != "prototype": typer.echo(f"Unknown strategy: {strategy_name}", err=True); raise typer.Exit(code=1)
+    final_memory_path_str = memory_path_arg if memory_path_arg is not None else ctx.obj.get("gist_memory_path")
+    if final_memory_path_str is None: typer.secho("Critical Error: Memory path could not be resolved.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    path = Path(final_memory_path_str)
+    if not path.exists(): typer.secho(f"Error: Memory path '{path}' not found or is invalid.", fg=typer.colors.RED, err=True); raise typer.Exit(code=1)
+    agent = _load_agent(path)
+    if list_prototypes:
+        protos = agent.get_prototypes_view()
+        table = Table("id", "strength", "confidence", "summary", title="Beliefs")
+        for p in protos: table.add_row(p["id"], f"{p['strength']:.2f}", f"{p['confidence']:.2f}", p["summary"][:60])
+        console.print(table)
 
-@app.command("compress")
-def compress_text(
-    input_source: str = typer.Argument(
-        ...,
-        help="Input text directly or path to a file or directory to compress",
-    ),
-    *,
-    strategy: str = typer.Option(..., help="Compression strategy"),
-    output_path: Optional[Path] = typer.Option(
-        None,
-        "-o",
-        "--output",
-        resolve_path=True,
-        help=(
-            "Path to write compressed output. For directories, this specifies the"
-            " root output directory."
-        ),
-    ),
-    output_trace: Optional[Path] = typer.Option(
-        None,
-        "--output-trace",
-        resolve_path=True,
-        help="Write CompressionTrace JSON to this file",
-    ),
-    recursive: bool = typer.Option(
-        False,
-        "-r",
-        "--recursive",
-        help="Process directories recursively",
-    ),
-    pattern: str = typer.Option(
-        "*.txt",
-        "-p",
-        "--pattern",
-        help="File glob pattern when reading from a directory",
-    ),
-    budget: int = typer.Option(..., help="Token budget"),
-    verbose_stats: bool = typer.Option(
-        False, "--verbose-stats", help="Show token counts and processing time"
-    ),
-) -> None:
-    """
-    Compress input text, file, or directory using a specified strategy to create a summary.
-
-    This command takes an input string, a single file, or all files in a directory (optionally recursively)
-    and compresses the content using the chosen strategy and token budget.
-    The result is a condensed version (summary) of the input.
-
-    Use 'gist-memory strategy list' to see available strategy IDs.
-
-    Usage Example:
-        gist-memory compress "This is a long text that needs to be summarized effectively." --strategy prototype --budget 50
-        gist-memory compress path/to/document.txt --strategy my_custom_strategy --budget 200 -o path/to/summary.txt
-    """
-
-    try:
-        import tiktoken
-
-        enc = tiktoken.get_encoding("gpt2")
-
-        def tokenizer(text: str, return_tensors=None) -> dict:
-            return {"input_ids": enc.encode(text)}
-
-    except Exception:  # pragma: no cover - offline
-        tokenizer = lambda t, **k: t.split()
-
-    source_as_path = Path(input_source)
-
-    if source_as_path.is_file():
-        if recursive or pattern != "*.txt":
-            if recursive:
-                typer.secho(
-                    "--recursive ignored for file input", fg=typer.colors.YELLOW
-                )
-            if pattern != "*.txt":
-                typer.secho("--pattern ignored for file input", fg=typer.colors.YELLOW)
-        _process_file_compression(
-            source_as_path,
-            strategy,
-            budget,
-            output_path,
-            verbose_stats,
-            tokenizer,
-            output_trace,
-        )
-    elif source_as_path.is_dir():
-        if "**" in pattern and not recursive:
-            typer.secho(
-                "Pattern includes '**' but --recursive not set; matching may miss subdirectories",
-                fg=typer.colors.YELLOW,
-            )
-        _process_directory_compression(
-            source_as_path,
-            strategy,
-            budget,
-            output_path,
-            recursive,
-            pattern,
-            verbose_stats,
-            tokenizer,
-            output_trace,
-        )
-    else:
-        if recursive or pattern != "*.txt":
-            if recursive:
-                typer.secho(
-                    "--recursive ignored for string input", fg=typer.colors.YELLOW
-                )
-            if pattern != "*.txt":
-                typer.secho(
-                    "--pattern ignored for string input", fg=typer.colors.YELLOW
-                )
-        _process_string_compression(
-            input_source,
-            strategy,
-            budget,
-            output_path,
-            output_trace,
-            verbose_stats,
-            tokenizer,
-        )
-
-
-@app.command("evaluate-compression")
-def evaluate_compression(
-    original_input: str = typer.Argument(..., help="Original text or file path"),
-    compressed_input: str = typer.Argument(
-        ..., help="Compressed text or file path, or '-' for stdin"
-    ),
-    metric_id: str = typer.Option(..., "--metric", "-m", help="Metric ID"),
-    metric_params_json: Optional[str] = typer.Option(
-        None, "--metric-params", help="Metric parameters as JSON"
-    ),
-    json_output: bool = typer.Option(False, "--json", help="JSON output"),
-) -> None:
-    """
-    Evaluates the quality of compressed text against the original using a specified metric.
-
-    This command helps quantify how well the compression performed based on criteria
-    like information retention, size reduction, etc. Use `gist-memory metric list`
-    to see available metric IDs.
-
-    Usage Example:
-        gist-memory evaluate-compression "Original long text..." "Compressed summary." --metric compression_ratio
-    """
-    # import sys # Moved to top
-    # import json # Global import
-    # from .registry import get_validation_metric_class # Moved to top
-
+@dev_app.command("evaluate-compression")
+def evaluate_compression_cmd(original_input: str = typer.Argument(..., help="Original text or file path"), compressed_input: str = typer.Argument(..., help="Compressed text or file path, or '-' for stdin"), metric_id: str = typer.Option(..., "--metric", "-m", help="Metric ID"), metric_params_json: Optional[str] = typer.Option(None, "--metric-params", help="Metric parameters as JSON"), json_output: bool = typer.Option(False, "--json", help="JSON output")) -> None:
     def read_input(value: str, allow_stdin: bool) -> str:
         if value == "-":
-            if not allow_stdin:
-                typer.secho("stdin already used", err=True, fg=typer.colors.RED)
-                raise typer.Exit(code=1)
+            if not allow_stdin: typer.secho("stdin already used", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
             return sys.stdin.read()
-        p = Path(value)
-        if p.exists() and p.is_file():
-            return p.read_text()
+        p = Path(value);
+        if p.exists() and p.is_file(): return p.read_text()
         return value
-
-    orig_text = read_input(original_input, True)
-    comp_text = read_input(compressed_input, compressed_input == "-")
-
-    try:
-        Metric = get_validation_metric_class(metric_id)
-    except KeyError:
-        typer.secho(f"Unknown metric '{metric_id}'", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
+    orig_text = read_input(original_input, True); comp_text = read_input(compressed_input, compressed_input == "-")
+    try: Metric = get_validation_metric_class(metric_id)
+    except KeyError: typer.secho(f"Unknown metric '{metric_id}'", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     params = {}
     if metric_params_json:
-        try:
-            params = json.loads(metric_params_json)
-        except json.JSONDecodeError as exc:
-            typer.secho(f"Invalid metric params: {exc}", err=True, fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
+        try: params = json.loads(metric_params_json)
+        except json.JSONDecodeError as exc: typer.secho(f"Invalid metric params: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     metric = Metric(**params)
-    try:
-        scores = metric.evaluate(original_text=orig_text, compressed_text=comp_text)
-    except Exception as exc:
-        typer.secho(f"Metric error: {exc}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
-    if json_output:
-        typer.echo(json.dumps(scores))
+    try: scores = metric.evaluate(original_text=orig_text, compressed_text=comp_text)
+    except Exception as exc: typer.secho(f"Metric error: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    if json_output: typer.echo(json.dumps(scores))
     else:
-        for k, v in scores.items():
-            typer.echo(f"{k}: {v}")
+        for k, v in scores.items(): typer.echo(f"{k}: {v}")
 
-
-@app.command("llm-prompt")
-def llm_prompt(
-    *,
-    context_input: str = typer.Option(
-        ..., "--context", "-c", help="Compressed context string, path, or '-' for stdin"
-    ),
-    query: str = typer.Option(..., "--query", "-q", help="User query"),
-    model_id: str = typer.Option("tiny-gpt2", "--model", help="Model ID"),
-    system_prompt: Optional[str] = typer.Option(
-        None, "--system-prompt", "-s", help="Optional system prompt"
-    ),
-    max_new_tokens: int = typer.Option(150, help="Max new tokens"),
-    output_llm_response_file: Optional[Path] = typer.Option(
-        None, "--output-response", help="File to save response"
-    ),
-    llm_config_file: Optional[Path] = typer.Option(
-        Path("llm_models_config.yaml"),
-        "--llm-config",
-        exists=True,
-        dir_okay=False,
-        resolve_path=True,
-        help="LLM config file",
-    ),
-    api_key_env_var: Optional[str] = typer.Option(None, help="Env var for API key"),
-) -> None:
-    """
-    Sends a constructed prompt (context + query) to a specified Language Model (LLM).
-
-    This command is useful for testing how an LLM responds when provided with
-    context that has been compressed by one of the strategies. You can specify
-    the model, system prompt, and other parameters.
-
-    Usage Example:
-        gist-memory llm-prompt --context "My compressed context about AI." --query "What are the key points?" --model-id gpt-3.5-turbo
-    """
-    # import sys # Moved to top
-    # import json # Global import
-    # import yaml # Global import
-    # from .llm_providers import OpenAIProvider, GeminiProvider, LocalTransformersProvider # Moved to top
-
+@dev_app.command("test-llm-prompt")
+def test_llm_prompt(*, context_input: str = typer.Option(..., "--context", "-c", help="Compressed context string, path, or '-' for stdin"), query: str = typer.Option(..., "--query", "-q", help="User query"), model_id: str = typer.Option("tiny-gpt2", "--model", help="Model ID"), system_prompt: Optional[str] = typer.Option(None, "--system-prompt", "-s", help="Optional system prompt"), max_new_tokens: int = typer.Option(150, help="Max new tokens"), output_llm_response_file: Optional[Path] = typer.Option(None, "--output-response", help="File to save response"), llm_config_file: Optional[Path] = typer.Option(Path("llm_models_config.yaml"), "--llm-config", exists=True, dir_okay=False, resolve_path=True, help="LLM config file"), api_key_env_var: Optional[str] = typer.Option(None, help="Env var for API key")) -> None:
     def read_val(val: str) -> str:
-        if val == "-":
-            return sys.stdin.read()
-        p = Path(val)
-        if p.exists() and p.is_file():
-            return p.read_text()
+        if val == "-": return sys.stdin.read()
+        p = Path(val);
+        if p.exists() and p.is_file(): return p.read_text()
         return val
-
-    context_text = read_val(context_input)
-
-    cfg = {}
+    context_text = read_val(context_input); cfg = {}
     if llm_config_file:
-        try:
-            cfg = yaml.safe_load(llm_config_file.read_text()) or {}
-        except Exception as exc:
-            typer.secho(f"Error loading config: {exc}", err=True, fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-    model_cfg = cfg.get(model_id, {"provider": "local", "model_name": model_id})
-    provider_name = model_cfg.get("provider")
-    model_name = model_cfg.get("model_name", model_id)
-
-    if provider_name == "openai":
-        provider = llm_providers.OpenAIProvider()
-    elif provider_name == "gemini":
-        provider = llm_providers.GeminiProvider()
-    else:
-        provider = llm_providers.LocalTransformersProvider()
-
-    api_key = os.getenv(api_key_env_var) if api_key_env_var else None
-
-    prompt_parts = []
-    if system_prompt:
-        prompt_parts.append(system_prompt)
-    prompt_parts.append(context_text)
-    prompt_parts.append(query)
-    prompt = "\n".join(part for part in prompt_parts if part)
-
-    try:
-        response = provider.generate_response(
-            prompt,
-            model_name=model_name,
-            max_new_tokens=max_new_tokens,
-            api_key=api_key,
-        )
-    except Exception as exc:
-        typer.secho(f"LLM error: {exc}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
+        try: cfg = yaml.safe_load(llm_config_file.read_text()) or {}
+        except Exception as exc: typer.secho(f"Error loading config: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    model_cfg = cfg.get(model_id, {"provider": "local", "model_name": model_id}); provider_name = model_cfg.get("provider"); model_name = model_cfg.get("model_name", model_id)
+    if provider_name == "openai": provider = llm_providers.OpenAIProvider()
+    elif provider_name == "gemini": provider = llm_providers.GeminiProvider()
+    else: provider = llm_providers.LocalTransformersProvider()
+    api_key = os.getenv(api_key_env_var) if api_key_env_var else None; prompt_parts = []
+    if system_prompt: prompt_parts.append(system_prompt)
+    prompt_parts.append(context_text); prompt_parts.append(query); prompt = "\n".join(part for part in prompt_parts if part)
+    try: response = provider.generate_response(prompt, model_name=model_name, max_new_tokens=max_new_tokens, api_key=api_key)
+    except Exception as exc: typer.secho(f"LLM error: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     if output_llm_response_file:
-        try:
-            output_llm_response_file.write_text(response)
-        except Exception as exc:
-            typer.secho(
-                f"Error writing {output_llm_response_file}: {exc}",
-                err=True,
-                fg=typer.colors.RED,
-            )
-            raise typer.Exit(code=1)
-    else:
-        typer.echo(response)
+        try: output_llm_response_file.write_text(response)
+        except Exception as exc: typer.secho(f"Error writing {output_llm_response_file}: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    else: typer.echo(response)
 
-
-@app.command("evaluate-llm-response")
-def evaluate_llm_response(
-    response_input: str = typer.Argument(
-        ..., help="LLM response text or file, or '-' for stdin"
-    ),
-    reference_input: str = typer.Argument(..., help="Reference answer text or file"),
-    metric_id: str = typer.Option(..., "--metric", "-m", help="Metric ID"),
-    metric_params_json: Optional[str] = typer.Option(
-        None, "--metric-params", help="Metric parameters as JSON"
-    ),
-    json_output: bool = typer.Option(False, "--json", help="JSON output"),
-) -> None:
-    """
-    Evaluates an LLM's response against a reference (ground truth) answer using a specified metric.
-
-    This helps in assessing the performance of an LLM in tasks like question answering
-    or summarization when its responses are compared to known good answers.
-    Use `gist-memory metric list` to see available metric IDs.
-
-    Usage Example:
-        gist-memory evaluate-llm-response "LLM Output: The capital is Paris." "Reference Answer: Paris." --metric exact_match
-    """
-    # import sys # Moved to top
-    # import json # Global import
-    # from .registry import get_validation_metric_class # Moved to top
-
+@dev_app.command("evaluate-llm-response")
+def evaluate_llm_response_cmd(response_input: str = typer.Argument(..., help="LLM response text or file, or '-' for stdin"), reference_input: str = typer.Argument(..., help="Reference answer text or file"), metric_id: str = typer.Option(..., "--metric", "-m", help="Metric ID"), metric_params_json: Optional[str] = typer.Option(None, "--metric-params", help="Metric parameters as JSON"), json_output: bool = typer.Option(False, "--json", help="JSON output")) -> None:
     def read_value(val: str, allow_stdin: bool) -> str:
         if val == "-":
-            if not allow_stdin:
-                typer.secho("stdin already used", err=True, fg=typer.colors.RED)
-                raise typer.Exit(code=1)
+            if not allow_stdin: typer.secho("stdin already used", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
             return sys.stdin.read()
-        p = Path(val)
-        if p.exists() and p.is_file():
-            return p.read_text()
+        p = Path(val);
+        if p.exists() and p.is_file(): return p.read_text()
         return val
-
-    resp_text = read_value(response_input, True)
-    ref_text = read_value(reference_input, False)
-
-    try:
-        Metric = get_validation_metric_class(metric_id)
-    except KeyError:
-        typer.secho(f"Unknown metric '{metric_id}'", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
+    resp_text = read_value(response_input, True); ref_text = read_value(reference_input, False)
+    try: Metric = get_validation_metric_class(metric_id)
+    except KeyError: typer.secho(f"Unknown metric '{metric_id}'", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     params = {}
     if metric_params_json:
-        try:
-            params = json.loads(metric_params_json)
-        except json.JSONDecodeError as exc:
-            typer.secho(f"Invalid metric params: {exc}", err=True, fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
+        try: params = json.loads(metric_params_json)
+        except json.JSONDecodeError as exc: typer.secho(f"Invalid metric params: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     metric = Metric(**params)
-    try:
-        scores = metric.evaluate(llm_response=resp_text, reference_answer=ref_text)
-    except Exception as exc:
-        typer.secho(f"Metric error: {exc}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
-    if json_output:
-        typer.echo(json.dumps(scores))
+    try: scores = metric.evaluate(llm_response=resp_text, reference_answer=ref_text)
+    except Exception as exc: typer.secho(f"Metric error: {exc}", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    if json_output: typer.echo(json.dumps(scores))
     else:
-        for k, v in scores.items():
-            typer.echo(f"{k}: {v}")
+        for k, v in scores.items(): typer.echo(f"{k}: {v}")
 
+@dev_app.command("download-embedding-model")
+def download_embedding_model_cli(model_name: str = typer.Option("all-MiniLM-L6-v2", help="SentenceTransformer model name")) -> None:
+    bar = tqdm(total=1, desc="Downloading embedding model", disable=False) # Corrected description
+    util_download_embedding_model(model_name) # Use aliased import
+    bar.update(1); bar.close(); typer.echo(f"Downloaded {model_name}")
 
-@app.command()
-def validate(
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-) -> None:
-    """
-    Checks the integrity and validity of an existing agent data store.
-
-    This command verifies that the agent's metadata, embedding dimensions,
-    and file structures are correct and consistent. It's useful for diagnosing
-    potential issues with an agent store.
-
-    Usage Example:
-        gist-memory validate --memory-path path/to/my_agent
-    """
-    path = Path(memory_path)
-    if not path.exists():
-        typer.secho(
-            f"Error: Memory path '{path}' not found or is invalid.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    try:
-        JsonNpyVectorStore(path=str(path))
-    except EmbeddingDimensionMismatchError as exc:
-        typer.secho(
-            f"Embedding dimension mismatch: {exc}", err=True, fg=typer.colors.RED
-        )
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - unexpected errors
-        typer.secho(f"Error loading agent: {exc}", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-    typer.echo("Store is valid")
-
-
-@app.command()
-def clear(
-    memory_path: str = typer.Option(
-        DEFAULT_MEMORY_PATH,
-        "--memory-path",
-        "-m",
-        help="Memory store directory",
-    ),
-    yes: bool = typer.Option(False, "--yes", help="Confirm deletion"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Do not delete files"),
-) -> None:
-    """
-    Deletes all data within the specified agent store, including memories and prototypes.
-
-    This is a destructive operation and requires confirmation via the --yes flag
-    unless --dry-run is used. Use with caution.
-
-    Usage Example (will prompt for confirmation):
-        gist-memory clear --memory-path path/to/my_agent
-
-    Usage Example (will not prompt, immediately deletes):
-        gist-memory clear --memory-path path/to/my_agent --yes
-    """
-    path = Path(memory_path)
-    if not path.exists():
-        typer.secho(
-            f"Error: Memory path '{path}' not found or is invalid.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    if dry_run:
-        store = JsonNpyVectorStore(path=str(path))
-        typer.echo(
-            f"Would delete {len(store.prototypes)} prototypes and {len(store.memories)} memories."
-        )
-        return
-    if not yes:
-        if not typer.confirm(
-            f"Delete {path}?", abort=True
-        ):  # pragma: no cover - user abort
-            return
-    if path.exists():
-        shutil.rmtree(path)
-        typer.echo(f"Deleted {path}")
-    else:
-        typer.secho("Directory not found", err=True, fg=typer.colors.RED)
-
-
-@app.command("download-model")
-def download_model(
-    model_name: str = typer.Option(
-        "all-MiniLM-L6-v2", help="SentenceTransformer model name"
-    ),
-) -> None:
-    """
-    Pre-downloads a specified sentence transformer model for generating embeddings.
-
-    This is useful to ensure the model is available locally, especially in
-    environments with limited internet access or to avoid download delays
-    during agent initialization or operation.
-
-    Usage Example:
-        gist-memory download-model --model-name sentence-transformers/all-MiniLM-L12-v2
-    """
-    # from tqdm import tqdm # Moved to top
-    # from .model_utils import download_embedding_model # Moved to top
-
-    bar = tqdm(total=1, desc="Downloading model", disable=False)
-    download_embedding_model(model_name)
-    bar.update(1)
-    bar.close()
-    typer.echo(f"Downloaded {model_name}")
-
-
-@app.command("download-chat-model")
-def download_chat_model(
-    model_name: str = typer.Option("tiny-gpt2", help="Local causal LM name"),
-) -> None:
-    """
-    Pre-downloads a specified local language model for use with the `talk` command.
-
-    This ensures the chat model is available locally, which can speed up
-    the `talk` command's first run and is helpful for offline usage.
-
-    Usage Example:
-        gist-memory download-chat-model --model-name tiny-gpt2
-    """
-    # from tqdm import tqdm # Moved to top
-    # from .model_utils import download_chat_model as _download_chat_model # Moved to top
-
+@dev_app.command("download-chat-model")
+def download_chat_model_cli(model_name: str = typer.Option("tiny-gpt2", help="Local causal LM name")) -> None:
     bar = tqdm(total=1, desc="Downloading chat model", disable=False)
-    _download_chat_model(model_name)
-    bar.update(1)
-    bar.close()
-    typer.echo(f"Downloaded {model_name}")
+    util_download_chat_model(model_name) # Use aliased import
+    bar.update(1); bar.close(); typer.echo(f"Downloaded {model_name}")
 
-
-@experiment_app.command("ingest")
-def run_experiment_cmd(
-    dataset: Path = typer.Argument(..., help="Text file to ingest"),
-    work_dir: Optional[Path] = typer.Option(
-        None, help="Directory for the temporary store"
-    ),
-    similarity_threshold: float = typer.Option(
-        0.8, "--tau", help="Similarity threshold"
-    ),
-    json_output: bool = typer.Option(False, "--json", help="JSON output"),
-) -> None:
-    """
-    Run a simple ingestion experiment.
-
-    This command processes a dataset (e.g., a text file) to build or update the agent's memory.
-    During ingestion, new information is chunked and then either assigned to an existing
-    prototype or used to create a new one based on similarity.
-
-    Prototypes are representative summaries of related memories.
-
-    Usage Example:
-        gist-memory experiment ingest path/to/dataset.txt --tau 0.75
-    """
-    # from .experiment_runner import ExperimentConfig, run_experiment # Moved to top
-
-    cfg = ExperimentConfig(
-        dataset=dataset, similarity_threshold=similarity_threshold, work_dir=work_dir
-    )
-    metrics = run_experiment(cfg)
-    if json_output:
-        typer.echo(json.dumps(metrics))
-    else:
-        for k, v in metrics.items():
-            typer.echo(f"{k}: {v}")
-
-
-@package_app.command("create")
-def package_create(
-    name: str = typer.Option("sample_strategy", "--name", help="Strategy name"),
-    path: Optional[Path] = typer.Option(None, "--path", help="Output directory"),
-) -> None:
-    """
-    Generates a template for creating a new custom strategy package.
-
-    This command creates a directory with the basic structure and files needed
-    to develop and package a new compression strategy.
-
-    Usage Example:
-        gist-memory package create --name my_new_strategy
-    """
-    target = Path(path or name)
-    target.mkdir(parents=True, exist_ok=True)
+@dev_app.command("create-strategy-package")
+def create_strategy_package(name: str = typer.Option("sample_strategy", "--name", help="Strategy name"), path: Optional[Path] = typer.Option(None, "--path", help="Output directory")) -> None:
+    target = Path(path or name); target.mkdir(parents=True, exist_ok=True)
     (target / "experiments").mkdir(exist_ok=True)
-    (target / "strategy.py").write_text(
-        """from gist_memory.compression.strategies_abc import CompressionStrategy, CompressedMemory, CompressionTrace\n\n\nclass MyStrategy(CompressionStrategy):\n    id = \"{}\"\n\n    def compress(self, text_or_chunks, llm_token_budget, **kwargs):\n        return CompressedMemory(text=str(text_or_chunks)), CompressionTrace()\n""".format(
-            name
-        )
-    )
-    manifest = {
-        "package_format_version": "1.0",
-        "strategy_id": name,
-        "strategy_class_name": "MyStrategy",
-        "strategy_module": "strategy",
-        "display_name": name,
-        "version": "0.1.0",
-        "authors": [],
-        "description": "Describe the strategy",
-    }
-    # import yaml # Global import
-
+    (target / "strategy.py").write_text(f"""from gist_memory.compression.strategies_abc import CompressionStrategy, CompressedMemory, CompressionTrace\n\n\nclass MyStrategy(CompressionStrategy):\n    id = "{name}"\n\n    def compress(self, text_or_chunks, llm_token_budget, **kwargs):\n        return CompressedMemory(text=str(text_or_chunks)), CompressionTrace()\n""")
+    manifest = {"package_format_version": "1.0", "strategy_id": name, "strategy_class_name": "MyStrategy", "strategy_module": "strategy", "display_name": name, "version": "0.1.0", "authors": [], "description": "Describe the strategy"}
     (target / "strategy_package.yaml").write_text(yaml.safe_dump(manifest))
-    (target / "requirements.txt").write_text("\n")
-    (target / "README.md").write_text(f"# {name}\n")
-    (target / "experiments" / "example.yaml").write_text(
-        """dataset: example.txt\nparam_grid:\n- {}\npackaged_strategy_config:\n  strategy_params: {}\n"""
-    )
+    (target / "requirements.txt").write_text("\n"); (target / "README.md").write_text(f"# {name}\n")
+    (target / "experiments" / "example.yaml").write_text("""dataset: example.txt\nparam_grid:\n- {}\npackaged_strategy_config:\n  strategy_params: {}\n""")
     typer.echo(f"Created package at {target}")
 
-
-@package_app.command("validate")
-def package_validate(package_path: Path) -> None:
-    """
-    Validates the structure, manifest file (strategy_package.yaml), and other
-    requirements for a custom strategy package.
-
-    This helps ensure the package is correctly formatted before sharing or use.
-
-    Usage Example:
-        gist-memory package validate path/to/my_package
-    """
+@dev_app.command("validate-strategy-package")
+def validate_strategy_package(package_path: Path) -> None:
     errors, warnings = validate_package_dir(package_path)
-    for w in warnings:
-        typer.secho(f"Warning: {w}", fg=typer.colors.YELLOW)
+    for w in warnings: typer.secho(f"Warning: {w}", fg=typer.colors.YELLOW)
     if errors:
-        for e in errors:
-            typer.echo(e)
+        for e in errors: typer.echo(e)
         raise typer.Exit(code=1)
     typer.echo("Package is valid")
 
-
-@experiment_app.command("run-package")
-def run_experiment_package(
-    package_path: Path = typer.Argument(..., help="Path to strategy package"),
-    experiment: Optional[str] = typer.Option(
-        None, "--experiment", help="Experiment config"
-    ),
-) -> None:
-    """
-    Runs an experiment defined within a specified strategy package.
-
-    Experiments are typically defined in YAML files within the package and
-    can be used to evaluate the packaged strategy's performance.
-
-    Usage Example:
-        gist-memory experiment run-package path/to/my_package --experiment experiment_config.yaml
-    """
-    manifest = load_manifest(package_path / "strategy_package.yaml")
-    Strategy = load_strategy_class(package_path, manifest)
-
+@dev_app.command("run-package-experiment")
+def run_package_experiment(package_path: Path = typer.Argument(..., help="Path to strategy package"), experiment: Optional[str] = typer.Option(None, "--experiment", help="Experiment config")) -> None:
+    manifest = load_manifest(package_path / "strategy_package.yaml"); Strategy = load_strategy_class(package_path, manifest)
     missing = check_requirements_installed(package_path / "requirements.txt")
-    if missing:
-        typer.secho(
-            f"Warning: missing requirements - {', '.join(missing)}",
-            fg=typer.colors.YELLOW,
-        )
+    if missing: typer.secho(f"Warning: missing requirements - {', '.join(missing)}", fg=typer.colors.YELLOW)
     if experiment is None:
         defaults = manifest.get("default_experiments", [])
-        if len(defaults) == 1:
-            experiment = defaults[0].get("path")
-    if experiment is None:
-        typer.secho("No experiment specified", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
+        if len(defaults) == 1: experiment = defaults[0].get("path")
+    if experiment is None: typer.secho("No experiment specified", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     exp_path = Path(experiment)
-    if not exp_path.is_absolute():
-        exp_path = package_path / exp_path
-    # import yaml # Global import
-
-    cfg_data = yaml.safe_load(exp_path.read_text()) or {}
-    dataset = cfg_data.get("dataset")
-    if dataset and not Path(dataset).is_absolute():
-        cfg_data["dataset"] = str((package_path / dataset).resolve())
+    if not exp_path.is_absolute(): exp_path = package_path / exp_path
+    cfg_data = yaml.safe_load(exp_path.read_text()) or {}; dataset = cfg_data.get("dataset")
+    if dataset and not Path(dataset).is_absolute(): cfg_data["dataset"] = str((package_path / dataset).resolve())
     params = cfg_data.get("param_grid", [{}])
-    cfg = ResponseExperimentConfig(
-        dataset=Path(cfg_data["dataset"]),
-        param_grid=params,
-        validation_metrics=cfg_data.get("validation_metrics"),
-    )
-    strategy_params = cfg_data.get("packaged_strategy_config", {}).get(
-        "strategy_params", {}
-    )
-    strategy = Strategy(**strategy_params)
-    results = run_response_experiment(cfg, strategy=strategy)
-    typer.echo(json.dumps(results))
+    cfg = ResponseExperimentConfig(dataset=Path(cfg_data["dataset"]), param_grid=params, validation_metrics=cfg_data.get("validation_metrics"))
+    strategy_params = cfg_data.get("packaged_strategy_config", {}).get("strategy_params", {}); strategy = Strategy(**strategy_params)
+    results = run_response_experiment(cfg, strategy=strategy); typer.echo(json.dumps(results))
 
-
-@experiment_app.command("optimize")
-def optimize_experiment(
-    script: Path = typer.Argument(..., help="Python script")
-) -> None:
-    """
-    Runs a hyperparameter optimization script for finding optimal strategy parameters.
-
-    The script should use a library like Optuna or Ray Tune to explore
-    different parameter combinations for a compression strategy.
-
-    Usage Example:
-        gist-memory experiment optimize path/to/optimization_script.py
-    """
-    if not script.exists():
-        typer.secho(f"Script '{script}' not found", err=True, fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-    # import runpy # Moved to top
-
+@dev_app.command("run-hpo-script")
+def run_hpo_script(script: Path = typer.Argument(..., help="Python script")) -> None:
+    if not script.exists(): typer.secho(f"Script '{script}' not found", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
     runpy.run_path(str(script), run_name="__main__")
 
-
-@trace_app.command("inspect")
-def trace_inspect(
-    trace_file: Path = typer.Argument(..., help="Path to trace JSON"),
-    step_type: Optional[str] = typer.Option(None, "--type", help="Filter by step type"),
-) -> None:
-    """
-    Prints a summary of a saved CompressionTrace JSON file.
-
-    This command helps in analyzing the steps taken by a compression strategy.
-    You can filter the displayed steps by their type (e.g., 'chunk', 'embed', 'cluster').
-
-    Usage Example:
-        gist-memory trace inspect path/to/trace.json --type filter_item
-    """
-
-    if not trace_file.exists():
-        typer.secho(
-            f"Trace file '{trace_file}' not found", err=True, fg=typer.colors.RED
-        )
-        raise typer.Exit(code=1)
-
-    # import json # Global import
-    # from rich.table import Table # Global import
-
-    data = json.loads(trace_file.read_text())
-    steps = data.get("steps", [])
-
+@dev_app.command("inspect-trace")
+def inspect_trace(trace_file: Path = typer.Argument(..., help="Path to trace JSON"), step_type: Optional[str] = typer.Option(None, "--type", help="Filter by step type")) -> None:
+    if not trace_file.exists(): typer.secho(f"Trace file '{trace_file}' not found", err=True, fg=typer.colors.RED); raise typer.Exit(code=1)
+    data = json.loads(trace_file.read_text()); steps = data.get("steps", [])
     console.print(f"Strategy: {data.get('strategy_name', '')}")
     table = Table("idx", "type", "details")
     for idx, step in enumerate(steps):
         stype = step.get("type")
-        if step_type and stype != step_type:
-            continue
-        preview = json.dumps(step.get("details", {}))[:50]
-        table.add_row(str(idx), stype or "", preview)
+        if step_type and stype != step_type: continue
+        preview = json.dumps(step.get("details", {}))[:50]; table.add_row(str(idx), stype or "", preview)
     console.print(table)
 
+# Commands still under @app.command that need to be moved or have their functionality subsumed
+# @app.command()
+# def validate_cmd(...)
+# @app.command("download-model") -> now dev_app.command("download-embedding-model")
+# @app.command("download-chat-model") -> now dev_app.command("download-chat-model")
 
 if __name__ == "__main__":
-    app()
+	app()

--- a/gist_memory/config.py
+++ b/gist_memory/config.py
@@ -1,9 +1,207 @@
-"""Shared configuration constants."""
-
 import os
+import pathlib
+import yaml
+from typing import Any, Dict, Optional
 
-# Default location for on-disk memory store. Can be overridden with the
-# ``GIST_MEMORY_PATH`` environment variable.
-DEFAULT_MEMORY_PATH = os.environ.get("GIST_MEMORY_PATH", "memory")
+# Default configuration values
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "gist_memory_path": "~/.local/share/gist_memory",
+    "default_model_id": "openai/gpt-3.5-turbo",
+    "default_strategy_id": "default",
+}
 
-__all__ = ["DEFAULT_MEMORY_PATH"]
+# Configuration file paths
+USER_CONFIG_DIR = pathlib.Path("~/.config/gist_memory").expanduser()
+USER_CONFIG_PATH = USER_CONFIG_DIR / "config.yaml"
+LOCAL_CONFIG_PATH = pathlib.Path(".gmconfig.yaml")
+
+# Environment variable prefixes
+ENV_VAR_PREFIX = "GIST_MEMORY_"
+
+class Config:
+    def __init__(self):
+        self._config = {}  # Initialize as empty, precedence will fill it
+        self._load_defaults()
+        self._load_user_config()
+        self._load_local_config()
+        self._load_env_vars()
+
+    def _load_defaults(self):
+        self._config.update(DEFAULT_CONFIG)
+
+    def _load_user_config(self):
+        if USER_CONFIG_PATH.exists():
+            try:
+                with open(USER_CONFIG_PATH, "r") as f:
+                    user_config = yaml.safe_load(f)
+                    if user_config:
+                        self._config.update(user_config)
+            except Exception as e:
+                print(f"Error loading user config: {e}")
+
+
+    def _load_local_config(self):
+        if LOCAL_CONFIG_PATH.exists():
+            try:
+                with open(LOCAL_CONFIG_PATH, "r") as f:
+                    local_config = yaml.safe_load(f)
+                    if local_config:
+                        self._config.update(local_config)
+            except Exception as e:
+                print(f"Error loading local config: {e}")
+
+    def _load_env_vars(self):
+        for key in DEFAULT_CONFIG.keys(): # Iterate over known config keys
+            env_var_name = ENV_VAR_PREFIX + key.upper()
+            env_var_value = os.getenv(env_var_name)
+            if env_var_value:
+                # Attempt to cast env var value to the type of the default value
+                default_value = DEFAULT_CONFIG[key]
+                try:
+                    if isinstance(default_value, bool):
+                        env_var_value = env_var_value.lower() in ("true", "1", "yes")
+                    else:
+                        env_var_value = type(default_value)(env_var_value)
+                    self._config[key] = env_var_value
+                except ValueError:
+                    print(f"Warning: Could not cast env var {env_var_name} to type {type(default_value)}. Using string value.")
+                    self._config[key] = env_var_value
+
+
+    def get(self, key: str) -> Any:
+        return self._config.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        # This method should primarily update the user global config.
+        # The runtime config (`self._config`) is already updated by the caller or will be on next load.
+
+        # Validate before setting
+        if key in DEFAULT_CONFIG:
+            default_value = DEFAULT_CONFIG[key]
+            if not isinstance(value, type(default_value)):
+                try:
+                    value = type(default_value)(value)
+                except ValueError:
+                    print(f"Error: Invalid type for '{key}'. Expected {type(default_value)}, got {type(value)}.")
+                    return
+
+        # Load current user config
+        user_config_data = {}
+        if USER_CONFIG_PATH.exists():
+            try:
+                with open(USER_CONFIG_PATH, "r") as f:
+                    loaded_config = yaml.safe_load(f)
+                    if isinstance(loaded_config, dict):
+                        user_config_data = loaded_config
+            except Exception as e:
+                print(f"Error reading user config before set: {e}")
+
+        # Update the specific key-value pair
+        user_config_data[key] = value
+
+        # Write back to user global config
+        try:
+            USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+            with open(USER_CONFIG_PATH, "w") as f:
+                yaml.dump(user_config_data, f)
+            # Update runtime config immediately for consistency if needed by application logic
+            self._config[key] = value
+        except Exception as e:
+            print(f"Error writing to user config: {e}")
+
+
+    def validate(self) -> bool:
+        for key, default_value in DEFAULT_CONFIG.items():
+            if key not in self._config:
+                print(f"Validation Error: Missing configuration key: {key}")
+                return False
+
+            current_value = self._config[key]
+            if not isinstance(current_value, type(default_value)):
+                # Attempt type coercion for strings from env vars, if they are compatible
+                if isinstance(current_value, str):
+                    try:
+                        if isinstance(default_value, bool):
+                             #This case should ideally be handled during load_env_vars
+                            coerced_value = current_value.lower() in ('true', '1', 'yes')
+                        else:
+                            coerced_value = type(default_value)(current_value)
+
+                        if not isinstance(coerced_value, type(default_value)):
+                           raise ValueError("Coercion did not result in the correct type")
+                        self._config[key] = coerced_value # Update with coerced value
+                    except ValueError:
+                        print(f"Validation Error: Configuration key '{key}' has incorrect type. Expected {type(default_value)}, got {type(current_value)}.")
+                        return False
+                else:
+                    print(f"Validation Error: Configuration key '{key}' has incorrect type. Expected {type(default_value)}, got {type(current_value)}.")
+                    return False
+        return True
+
+if __name__ == "__main__":
+    # Test basic loading and precedence (manual setup for testing)
+    print(f"Default config: {DEFAULT_CONFIG}")
+
+    # Create dummy user config
+    USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(USER_CONFIG_PATH, "w") as f:
+        yaml.dump({"gist_memory_path": "/user/path", "default_model_id": "user/model"}, f)
+
+    # Create dummy local config
+    with open(LOCAL_CONFIG_PATH, "w") as f:
+        yaml.dump({"default_model_id": "local/model", "default_strategy_id": "local_strategy"}, f)
+
+    # Set environment variables
+    os.environ[ENV_VAR_PREFIX + "DEFAULT_STRATEGY_ID"] = "env_strategy"
+    os.environ[ENV_VAR_PREFIX + "GIST_MEMORY_PATH"] = "/env/path"
+
+
+    config = Config()
+    print(f"\nLoaded config object: {config._config}")
+    print(f"GIST_MEMORY_PATH: {config.get('gist_memory_path')}") # Expected: /env/path (Env)
+    print(f"DEFAULT_MODEL_ID: {config.get('default_model_id')}") # Expected: local/model (Local)
+    print(f"DEFAULT_STRATEGY_ID: {config.get('default_strategy_id')}") # Expected: env_strategy (Env)
+
+    print(f"\nValidation result before set: {config.validate()}")
+
+    # Test set
+    print("\nTesting set function...")
+    config.set("default_model_id", "new_user_model_via_set")
+
+    # Verify runtime config updated
+    print(f"Config after set (runtime): {config.get('default_model_id')}")
+
+    # Verify user config file updated
+    if USER_CONFIG_PATH.exists():
+        with open(USER_CONFIG_PATH, "r") as f:
+            user_conf_after_set = yaml.safe_load(f)
+            print(f"User config file after set: {user_conf_after_set}")
+    else:
+        print("User config file not found after set.")
+
+    config.set("new_setting", "test_value") # Test setting a new key
+    print(f"Config after set (new_setting): {config.get('new_setting')}")
+    if USER_CONFIG_PATH.exists():
+        with open(USER_CONFIG_PATH, "r") as f:
+            user_conf_after_set_new = yaml.safe_load(f)
+            print(f"User config file after set (new_setting): {user_conf_after_set_new}")
+
+    print(f"\nValidation result after set: {config.validate()}")
+
+    # Clean up dummy files and env vars
+    if USER_CONFIG_PATH.exists():
+        os.remove(USER_CONFIG_PATH)
+    if LOCAL_CONFIG_PATH.exists():
+        os.remove(LOCAL_CONFIG_PATH)
+    del os.environ[ENV_VAR_PREFIX + "DEFAULT_STRATEGY_ID"]
+    del os.environ[ENV_VAR_PREFIX + "GIST_MEMORY_PATH"]
+
+    print("\nTesting with a missing key for validation...")
+    temp_config = Config()
+    del temp_config._config['default_model_id'] # Manually remove a key
+    print(f"Validation with missing key: {temp_config.validate()}")
+
+    print("\nTesting with a type mismatch for validation...")
+    temp_config_type = Config()
+    temp_config_type._config['default_model_id'] = 123 # Introduce type error
+    print(f"Validation with type mismatch: {temp_config_type.validate()}")


### PR DESCRIPTION
This commit implements Phase 1 (Global Configuration) and a significant portion of Phase 2 (CLI Restructuring) as per our plan.

**Phase 1: Global Configuration System**

- I implemented a core configuration system.
  - It supports YAML format.
  - It reads from environment variables.
  - It follows a specific order of precedence for settings.
  - It allows writing to the global config file.
  - It includes basic validation.
- I integrated global options into the root CLI callback.
  - Resolved values are stored for use.
- I implemented interactive prompts for essential missing configurations if you are running this in a terminal.

**Phase 2: CLI Command Restructuring (Partial)**

- **New Command Groups:**
  - `agent`: For agent management.
  - `config`: For configuration management.
  - `dev`: For developer tools.
- **Top-Level Commands:**
  - `query`: For querying the agent.
  - `summarize`: For summarizing text.
  - `ingest`: Placeholder created (implementation to follow).
- **Command Migrations:**
  - I migrated `agent init`, which now takes a `<target_directory>` argument.
  - I migrated `agent clear`, which now uses a `--force` flag.
  - I migrated `agent stats`.
  - I migrated most development-related and former grouped commands to the `dev` group.

**Challenges Encountered:**
- I noticed some inconsistencies when checking on progress, which sometimes showed information for previously completed steps instead of the most recent one. This required me to carefully re-verify the state of your codebase and sometimes re-evaluate certain steps or group them differently to ensure progress.

**Next Steps (Continuing Phase 2):**
- I will verify/complete the migration of `validate_cmd` to `agent validate`.
- I will implement the `ingest` command by migrating `run_experiment_cmd`.
- I will implement `config set` and `config show` commands.
- I will implement the parameter parsing utility.