### PR TITLE
Update README setup docs for online envs

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Setup script executed during Codex container setup.
-# Codex loses network access after this step, so we download all assets
-# needed for tests here to ensure offline execution.
+# Install dependencies used during testing and examples.
 
 set -euo pipefail
 
@@ -27,27 +26,4 @@ pip3 install flake8 pytest
 # CLI dependencies that may not be declared in requirements.txt
 pip3 install rich typer portalocker
 
-# Pre-download the default local embedding model so tests work offline
-python3 - <<'PY'
-from sentence_transformers import SentenceTransformer
-
-# Use the fully qualified model name to ensure the cached path
-# matches calls within the repo which expect
-# "sentence-transformers/all-MiniLM-L6-v2".
-SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
-PY
-
-# Pre-download the default chat model used in talk mode
-python3 - <<'PY'
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
-AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
-AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
-PY
-
-# Ensure the GPT-2 tokenizer files are available for tiktoken
-python3 - <<'PY'
-import tiktoken
-tiktoken.get_encoding("gpt2")
-PY
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,6 @@ Key benefits include:
 
 This project requires **Python 3.11+**.
 
-0.  **Run `setup.sh` (Optional for Offline-Friendly Environment):**
-    To prepare an offline-friendly development environment quickly, you can execute the provided script while you have internet access. This script pre-downloads many dependencies.
-    ```bash
-    ./setup.sh
-    ```
-    This step is optional; you can install dependencies directly if you prefer.
-
 1.  **Install Core Dependencies:**
     ```bash
     pip install -r requirements.txt
@@ -137,10 +130,6 @@ This project requires **Python 3.11+**.
         ```bash
         pip install .
         ```
-    *   **Offline Note:** If working in an offline environment after fetching the repository and dependencies (e.g., via `setup.sh`), you might need the `--no-build-isolation` flag with `pip install -e .` or `pip install .`. Alternatively, you can add the repository root to your `PYTHONPATH`:
-        ```bash
-        export PYTHONPATH="$(pwd):$PYTHONPATH"
-        ```
 
 3.  **Download Models for Examples and Testing (Optional but Recommended):**
     These models are used by some of the example strategies and for testing LLM interactions with compressed memory.
@@ -151,11 +140,6 @@ This project requires **Python 3.11+**.
     gist-memory dev download-chat-model --model-name tiny-gpt2
     ```
     Note: Specific `CompressionStrategy` implementations might have other model dependencies not covered here. Always check the documentation for the strategy you intend to use.
-    To run completely offline after all downloads, set:
-    ```
-    export HF_HUB_OFFLINE=1
-    export TRANSFORMERS_OFFLINE=1
-    ```
 
 4.  **Set API Keys for Cloud Providers (Optional):**
     If you plan to use OpenAI or Gemini models with `gist-memory`, export your API keys as environment variables:

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
-# Convenience script to install dependencies and download models.
-# Run this while online to enable offline use of the CLI and demos.
+# Convenience script to install dependencies and optional example models.
 set -euo pipefail
 
 pip install -r requirements.txt
 pip install -e . --no-build-isolation
 python -m spacy download en_core_web_sm
-
-# Pre-fetch models used in the examples and tests
-gist-memory download-model --model-name all-MiniLM-L6-v2
-gist-memory download-chat-model --model-name tiny-gpt2


### PR DESCRIPTION
## Summary
- remove offline `setup.sh` step from README
- clean up optional offline instructions
- simplify setup script now that we no longer pre-download models
- drop model prefetching from codex setup

## Testing
- `pytest -q` *(fails: FAILED tests/test_cli_utils.py::test_pcp_malformed_json_file ...)*

------
https://chatgpt.com/codex/tasks/task_e_683f4d89a6cc8329a152291a61d6cc57