### PR TITLE
Refactor default strategy config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ compact-memory dev list-strategies
 
 To use a specific strategy, you can set it as a global default or specify it per command:
 ```bash
-# Set default strategy globally
-compact-memory config set default_strategy_id prototype
+# Set default engine globally
+compact-memory config set default_engine_id prototype
 
 # Use a specific strategy for a compress command
 compact-memory compress --text "My text..." --strategy first_last --budget 100
@@ -207,7 +207,7 @@ compact-memory compress --text "My text..." --strategy first_last --budget 100
 Plugins can add more strategies. For example, the `rationale_episode` strategy lives in the optional
 `compact_memory_rationale_episode_strategy` package. Install it with
 `pip install compact_memory_rationale_episode_strategy` to enable it.
-You can then set it via `compact-memory config set default_strategy_id rationale_episode`.
+You can then set it via `compact-memory config set default_engine_id rationale_episode`.
 Note: The old method of enabling strategies via `compact_memory_config.yaml` directly is being phased out in favor of the `config set` command and plugin system.
 
 ### Using Experimental Strategies
@@ -314,7 +314,7 @@ You can also set a default location for the on-disk memory store and other globa
 
 Compact Memory uses a hierarchical configuration system:
 1.  **Command-line arguments:** Highest precedence (e.g., `compact-memory --memory-path ./my_memory ingest ...`).
-2.  **Environment variables:** (e.g., `COMPACT_MEMORY_PATH`, `COMPACT_MEMORY_DEFAULT_MODEL_ID`, `COMPACT_MEMORY_DEFAULT_STRATEGY_ID`).
+2.  **Environment variables:** (e.g., `COMPACT_MEMORY_PATH`, `COMPACT_MEMORY_DEFAULT_MODEL_ID`, `COMPACT_MEMORY_DEFAULT_ENGINE_ID`).
 3.  **Local project config:** `.gmconfig.yaml` in the current directory.
 4.  **User global config:** `~/.config/compact_memory/config.yaml`.
 5.  **Hardcoded defaults.**

--- a/compact_memory/cli.py
+++ b/compact_memory/cli.py
@@ -125,7 +125,7 @@ def main(
     strategy_id: Optional[str] = typer.Option(
         None,
         "--engine",
-        help="Default compression engine ID. Overrides COMPACT_MEMORY_DEFAULT_STRATEGY_ID env var and configuration files.",
+        help="Default compression engine ID. Overrides COMPACT_MEMORY_DEFAULT_ENGINE_ID env var and configuration files.",
     ),
     version: Optional[bool] = typer.Option(
         None,
@@ -162,7 +162,7 @@ def main(
         model_id if model_id is not None else config.get("default_model_id")
     )
     resolved_engine_id = (
-        strategy_id if strategy_id is not None else config.get("default_strategy_id")
+        strategy_id if strategy_id is not None else config.get("default_engine_id")
     )
 
     if resolved_memory_path:
@@ -231,7 +231,7 @@ def main(
             "log_file": resolved_log_file,
             "compact_memory_path": resolved_memory_path,
             "default_model_id": resolved_model_id,
-            "default_strategy_id": resolved_engine_id,
+            "default_engine_id": resolved_engine_id,
             # "config": config, # Already present
         }
     )
@@ -481,7 +481,7 @@ def query(
     store = InMemoryVectorStore(embedding_dim=dim)
     container = PrototypeEngine(store)
     final_model_id = ctx.obj.get("default_model_id")  # Renamed for clarity
-    final_engine_id = ctx.obj.get("default_strategy_id")  # Renamed for clarity
+    final_engine_id = ctx.obj.get("default_engine_id")  # Renamed for clarity
 
     if final_model_id is None:
         typer.secho(
@@ -631,11 +631,11 @@ def compress(
     ),
 ) -> None:
     final_engine_id = (
-        strategy_arg if strategy_arg is not None else ctx.obj.get("default_strategy_id")
+        strategy_arg if strategy_arg is not None else ctx.obj.get("default_engine_id")
     )
     if not final_engine_id:
         typer.secho(
-            "Error: Compression engine not specified. Use --engine option or set COMPACT_MEMORY_DEFAULT_STRATEGY_ID / config.",
+            "Error: Compression engine not specified. Use --engine option or set COMPACT_MEMORY_DEFAULT_ENGINE_ID / config.",
             fg=typer.colors.RED,
             err=True,
         )
@@ -1703,7 +1703,7 @@ def config_set_command(
 
 @config_app.command(
     "show",
-    help="Displays current Compact Memory configuration values, their effective settings, and their sources.\n\nUsage Examples:\n  compact-memory config show\n  compact-memory config show --key default_strategy_id",
+    help="Displays current Compact Memory configuration values, their effective settings, and their sources.\n\nUsage Examples:\n  compact-memory config show\n  compact-memory config show --key default_engine_id",
 )
 def config_show_command(
     ctx: typer.Context,

--- a/compact_memory/config.py
+++ b/compact_memory/config.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 DEFAULT_CONFIG: Dict[str, Any] = {
     "compact_memory_path": "~/.local/share/compact_memory",
     "default_model_id": "openai/gpt-3.5-turbo",
-    "default_strategy_id": "default",
+    "default_engine_id": "default",
     "verbose": False,
     "log_file": None,
 }

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -22,7 +22,7 @@ Compact Memory uses a hierarchical configuration system. Settings are resolved i
 2.  **Environment Variables:**
     *   `COMPACT_MEMORY_PATH`
     *   `COMPACT_MEMORY_DEFAULT_MODEL_ID`
-    *   `COMPACT_MEMORY_DEFAULT_STRATEGY_ID`
+    *   `COMPACT_MEMORY_DEFAULT_ENGINE_ID`
 3.  **Local Project Configuration:** A `.gmconfig.yaml` file in the current working directory.
 4.  **User Global Configuration:** A `config.yaml` file located in `~/.config/compact_memory/config.yaml` (path may vary slightly by OS).
 5.  **Application Defaults:** Hardcoded default values within the application.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Compact Memory resolves settings from the following sources, in order of highest
     You can set specific environment variables to configure Compact Memory globally for your shell session or system.
     *   `COMPACT_MEMORY_PATH`: Sets the default path to your memory store.
     *   `COMPACT_MEMORY_DEFAULT_MODEL_ID`: Sets the default model ID for LLM interactions.
-    *   `COMPACT_MEMORY_DEFAULT_STRATEGY_ID`: Sets the default compression strategy ID.
+    *   `COMPACT_MEMORY_DEFAULT_ENGINE_ID`: Sets the default compression engine ID.
     *Example (bash):* `export COMPACT_MEMORY_PATH="/path/to/my/global_memory"`
 
 3.  **Local Project Configuration (`.gmconfig.yaml`):**
@@ -33,7 +33,7 @@ Compact Memory resolves settings from the following sources, in order of highest
     ```yaml
     compact_memory_path: ~/my_default_compact_memory
     default_model_id: openai/gpt-3.5-turbo
-    default_strategy_id: prototype
+    default_engine_id: prototype
     # You can also set log_file and verbose here
     # log_file: /path/to/compact_memory.log
     # verbose: false
@@ -78,13 +78,13 @@ You can set default values for key options to avoid typing them repeatedly. Thes
     ```
     Commands like `compact-memory query` will use this model by default.
 
-*   `default_strategy_id`: Your preferred compression strategy for summarization or queries (if applicable).
+*   `default_engine_id`: Your preferred compression engine for summarization or queries (if applicable).
     ```bash
-    compact-memory config set default_strategy_id prototype
+    compact-memory config set default_engine_id prototype
     ```
     Commands like `compact-memory compress` will use this strategy by default if you don't specify one with `--strategy`.
 
-*(Note: While `log_file` and `verbose` can be set in config files manually, they are primarily controlled via CLI options for runtime flexibility. The `config set` command currently supports `compact_memory_path`, `default_model_id`, and `default_strategy_id` as these are the most common global defaults users might want to persist.)*
+*(Note: While `log_file` and `verbose` can be set in config files manually, they are primarily controlled via CLI options for runtime flexibility. The `config set` command currently supports `compact_memory_path`, `default_model_id`, and `default_engine_id` as these are the most common global defaults users might want to persist.)*
 
 
 **Example Workflow:**

--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -371,7 +371,7 @@ def test_compress_nonexistent_dir(tmp_path: Path):
 
 def test_compress_uses_default_strategy(tmp_path: Path):
     env = _env(tmp_path)
-    env["COMPACT_MEMORY_DEFAULT_STRATEGY_ID"] = "none"
+    env["COMPACT_MEMORY_DEFAULT_ENGINE_ID"] = "none"
     result = runner.invoke(
         app,
         ["compress", "--text", "foobar", "--budget", "10"],
@@ -383,7 +383,7 @@ def test_compress_uses_default_strategy(tmp_path: Path):
 
 def test_compress_override_default_strategy(tmp_path: Path):
     env = _env(tmp_path)
-    env["COMPACT_MEMORY_DEFAULT_STRATEGY_ID"] = DummyTruncEngine.id
+    env["COMPACT_MEMORY_DEFAULT_ENGINE_ID"] = DummyTruncEngine.id
     result = runner.invoke(
         app,
         [

--- a/tests/test_cli_ingest_query.py
+++ b/tests/test_cli_ingest_query.py
@@ -13,7 +13,7 @@ runner = CliRunner()
 def _env(tmp_path: Path) -> dict[str, str]:
     return {
         "COMPACT_MEMORY_COMPACT_MEMORY_PATH": str(tmp_path),
-        "COMPACT_MEMORY_DEFAULT_STRATEGY_ID": "none",
+        "COMPACT_MEMORY_DEFAULT_ENGINE_ID": "none",
         "COMPACT_MEMORY_DEFAULT_MODEL_ID": "tiny-gpt2",
     }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,24 +60,24 @@ def test_local_config_override(monkeypatch: pytest.MonkeyPatch, patched_config: 
     local_file = cfg.LOCAL_CONFIG_PATH
     local_file.write_text(
         yaml.dump(
-            {"default_model_id": "local/model", "default_strategy_id": "local_strategy"}
+            {"default_model_id": "local/model", "default_engine_id": "local_strategy"}
         )
     )
     conf = cfg.Config()
     assert conf.get("default_model_id") == "local/model"
     assert conf.get_with_source("default_model_id")[1] == cfg.SOURCE_LOCAL_CONFIG
-    assert conf.get("default_strategy_id") == "local_strategy"
-    assert conf.get_with_source("default_strategy_id")[1] == cfg.SOURCE_LOCAL_CONFIG
+    assert conf.get("default_engine_id") == "local_strategy"
+    assert conf.get_with_source("default_engine_id")[1] == cfg.SOURCE_LOCAL_CONFIG
 
 
 def test_env_var_override(monkeypatch: pytest.MonkeyPatch, patched_config: Path):
-    monkeypatch.setenv(cfg.ENV_VAR_PREFIX + "DEFAULT_STRATEGY_ID", "env_strategy")
+    monkeypatch.setenv(cfg.ENV_VAR_PREFIX + "DEFAULT_ENGINE_ID", "env_strategy")
     monkeypatch.setenv(cfg.ENV_VAR_PREFIX + "COMPACT_MEMORY_PATH", "/env/path")
     conf = cfg.Config()
     assert conf.get("compact_memory_path") == "/env/path"
     assert conf.get_with_source("compact_memory_path")[1].startswith(cfg.SOURCE_ENV_VAR)
-    assert conf.get("default_strategy_id") == "env_strategy"
-    assert conf.get_with_source("default_strategy_id")[1].startswith(cfg.SOURCE_ENV_VAR)
+    assert conf.get("default_engine_id") == "env_strategy"
+    assert conf.get_with_source("default_engine_id")[1].startswith(cfg.SOURCE_ENV_VAR)
 
 
 def test_update_from_cli(patched_config: Path):


### PR DESCRIPTION
## Summary
- rename `default_strategy_id` to `default_engine_id`
- adjust CLI startup for `COMPACT_MEMORY_DEFAULT_ENGINE_ID`
- update docs and tests for new configuration key

## Testing
- `pre-commit run --files README.md compact_memory/cli.py compact_memory/config.py docs/cli_reference.md docs/configuration.md tests/test_cli_compress.py tests/test_cli_ingest_query.py tests/test_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419c5a52608329849678251ff74146