### PR TITLE
Fix none engine metrics

### DIFF
--- a/engine_metrics.json
+++ b/engine_metrics.json
@@ -8,8 +8,8 @@
     "embedding_similarity": 0.7314000129699707
   },
   "none": {
-    "compression_ratio": 0.3037220843672457,
-    "embedding_similarity": 0.8013756275177002
+    "compression_ratio": 1.0,
+    "embedding_similarity": 0.9999998807907104
   },
   "pipeline": {
     "compression_ratio": 0.2317617866004963,

--- a/examples/collect_engine_metrics.py
+++ b/examples/collect_engine_metrics.py
@@ -54,6 +54,10 @@ def main(output_file: str = "engine_metrics.json") -> None:
             compressed, _ = engine.compress(
                 "What is the text about?", 100, tokenizer=lambda t: t.split()
             )
+        elif eng_id == "none":
+            # Disable truncation for the no-op engine so the metrics reflect
+            # a true no-compression baseline.
+            compressed, _ = engine.compress(text, llm_token_budget=None)
         else:
             compressed, _ = engine.compress(text, llm_token_budget=100)
 


### PR DESCRIPTION
## Summary
- collect metrics for the `none` engine without truncation
- update example metrics output

## Testing
- `pre-commit run --files examples/collect_engine_metrics.py`
- `pytest`
- `python examples/collect_engine_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_6844e698758483299854bac4343f5d56