### PR TITLE
Remove mix_stderr argument from test runners

### DIFF
--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -7,15 +7,22 @@ from compact_memory.engines import (
     BaseCompressionEngine,
     CompressedMemory,
     CompressionTrace,
-    load_engine      # Added
+    load_engine,  # Added
 )
+
 # PrototypeEngine was removed
 
 
 class DummyTruncEngine(BaseCompressionEngine):
     id = "dummy_trunc"
 
-    def compress(self, text_or_chunks, llm_token_budget, previous_compression_result=None, **kwargs): # Added previous_compression_result and matched full signature
+    def compress(
+        self,
+        text_or_chunks,
+        llm_token_budget,
+        previous_compression_result=None,
+        **kwargs,
+    ):  # Added previous_compression_result and matched full signature
         text = (
             text_or_chunks
             if isinstance(text_or_chunks, str)
@@ -39,7 +46,7 @@ class DummyTruncEngine(BaseCompressionEngine):
             text=truncated,
             trace=trace,
             engine_id=self.id,
-            engine_config=getattr(self, 'config', None) # Mimic base engine
+            engine_config=getattr(self, "config", None),  # Mimic base engine
         )
 
 
@@ -50,12 +57,12 @@ def _env(tmp_path: Path) -> dict[str, str]:
     # Ensure this matches the expected env var name used by the application's config loader
     return {
         "COMPACT_MEMORY_PATH": str(tmp_path),
-        "COMPACT_MEMORY_DEFAULT_ENGINE_ID": "none", # Add defaults used by some tests
-        "COMPACT_MEMORY_DEFAULT_MODEL_ID": "tiny-gpt2", # Add defaults used by some tests
+        "COMPACT_MEMORY_DEFAULT_ENGINE_ID": "none",  # Add defaults used by some tests
+        "COMPACT_MEMORY_DEFAULT_MODEL_ID": "tiny-gpt2",  # Add defaults used by some tests
     }
 
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def test_compress_text_option(tmp_path: Path):
@@ -427,12 +434,14 @@ def test_compress_override_default_strategy(tmp_path: Path):
     assert result.exit_code == 0
     assert result.stdout.strip() == "abcdef"
 
+
 # Tests related to PrototypeEngine were removed:
 # - test_compress_to_memory_with_prototype_engine
 # - test_compress_to_memory_one_shot_trunc_then_prototype
 
 
 # --- Tests for PipelineEngine ---
+
 
 def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     """Test valid PipelineEngine usage with a simple pipeline."""
@@ -450,13 +459,21 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     # Output: "one two nine ten"
     expected_output = "one two nine ten"
 
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", pipeline_config_json,
-        "--text", text_to_compress,
-        "--budget", "10",  # Overall budget for the compress command
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            pipeline_config_json,
+            "--text",
+            text_to_compress,
+            "--budget",
+            "10",  # Overall budget for the compress command
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result.exit_code == 0, f"CLI Error: {result.stderr}"
     assert result.stdout.strip() == expected_output
@@ -475,7 +492,6 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     # Actual output of StopwordPrunerEngine can be sensitive to its exact stopword list.
     # FirstLastEngine will then take 1 from start, 1 from end of that.
     # For "example sentence common words", FirstLast(1,1) -> "example words"
-    expected_output_2 = "example sentence common words" # Output of StopwordPrunerEngine
     # Then FirstLastEngine takes first 1 and last 1.
     # This is a bit hard to predict exactly without running StopwordPruner,
     # so let's test if the command runs and produces *some* output.
@@ -484,32 +500,48 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     # If StopwordPrunerEngine is not available or fails, this test might be brittle.
     # Let's simplify expected output for robustness, assuming "example" and "words" survive.
 
-    result_2 = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", pipeline_config_json_2,
-        "--text", text_to_compress_2,
-        "--budget", "5",
-    ], env=_env(tmp_path))
+    result_2 = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            pipeline_config_json_2,
+            "--text",
+            text_to_compress_2,
+            "--budget",
+            "5",
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result_2.exit_code == 0, f"CLI Error: {result_2.stderr}"
     # Check for some expected keywords that should remain after stopword pruning
     assert "example" in result_2.stdout
     assert "words" in result_2.stdout
-    assert "this" not in result_2.stdout # "this" is a common stopword
+    assert "this" not in result_2.stdout  # "this" is a common stopword
 
 
 def test_cli_compress_pipeline_engine_invalid_json(tmp_path: Path):
     """Test PipelineEngine with invalid JSON in --pipeline-config."""
     invalid_json = '{"engines": [Oops this is not valid JSON}'
 
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", invalid_json,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            invalid_json,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result.exit_code != 0
     assert "Error decoding pipeline config JSON" in result.stderr
@@ -517,16 +549,26 @@ def test_cli_compress_pipeline_engine_invalid_json(tmp_path: Path):
 
 def test_cli_compress_pipeline_engine_missing_config(tmp_path: Path):
     """Test PipelineEngine usage when --pipeline-config is missing."""
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        # --pipeline-config is missing
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            # --pipeline-config is missing
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result.exit_code != 0
-    assert "Error: --pipeline-config is required when --engine is 'pipeline'." in result.stderr
+    assert (
+        "Error: --pipeline-config is required when --engine is 'pipeline'."
+        in result.stderr
+    )
 
 
 def test_cli_compress_pipeline_config_without_pipeline_engine(tmp_path: Path):
@@ -536,16 +578,27 @@ def test_cli_compress_pipeline_config_without_pipeline_engine(tmp_path: Path):
       "engines": [{"engine_name": "NoCompressionEngine", "engine_params": {}}]
     }
     """
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "none", # Not 'pipeline'
-        "--pipeline-config", pipeline_config_json,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "none",  # Not 'pipeline'
+            "--pipeline-config",
+            pipeline_config_json,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result.exit_code != 0
-    assert "Error: --pipeline-config can only be used when --engine is 'pipeline'." in result.stderr
+    assert (
+        "Error: --pipeline-config can only be used when --engine is 'pipeline'."
+        in result.stderr
+    )
 
 
 def test_cli_compress_pipeline_engine_unknown_sub_engine(tmp_path: Path):
@@ -557,53 +610,93 @@ def test_cli_compress_pipeline_engine_unknown_sub_engine(tmp_path: Path):
       ]
     }
     """
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", pipeline_config_json,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            pipeline_config_json,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
 
     assert result.exit_code != 0
     # The error message comes from the registry inside _get_one_shot_compression_engine
-    assert "Unknown one-shot compression engine 'ThisEngineDoesNotExist'" in result.stderr
+    assert (
+        "Unknown one-shot compression engine 'ThisEngineDoesNotExist'" in result.stderr
+    )
 
 
 def test_cli_compress_pipeline_engine_invalid_config_structure(tmp_path: Path):
     """Test PipelineEngine with a structurally invalid (but valid JSON) config."""
     # Valid JSON, but not the expected structure (e.g., 'engines' key missing)
     invalid_structure_json = '{"not_engines_key": []}'
-    result = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", invalid_structure_json,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            invalid_structure_json,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
     assert result.exit_code != 0
-    assert "Error creating pipeline engine from config" in result.stderr # General error
+    assert (
+        "Error creating pipeline engine from config" in result.stderr
+    )  # General error
 
     # Valid JSON, 'engines' is not a list
     invalid_structure_json_2 = '{"engines": {"engine_name": "NoCompressionEngine"}}'
-    result_2 = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", invalid_structure_json_2,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result_2 = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            invalid_structure_json_2,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
     assert result_2.exit_code != 0
-    assert "Pipeline config JSON must be a list" in result_2.stderr.lower() # Specific error from validation
+    assert (
+        "Pipeline config JSON must be a list" in result_2.stderr.lower()
+    )  # Specific error from validation
 
     # Valid JSON, list items are not dicts
     invalid_structure_json_3 = '{"engines": ["NoCompressionEngine"]}'
-    result_3 = runner.invoke(app, [
-        "compress",
-        "--engine", "pipeline",
-        "--pipeline-config", invalid_structure_json_3,
-        "--text", "some text",
-        "--budget", "10",
-    ], env=_env(tmp_path))
+    result_3 = runner.invoke(
+        app,
+        [
+            "compress",
+            "--engine",
+            "pipeline",
+            "--pipeline-config",
+            invalid_structure_json_3,
+            "--text",
+            "some text",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
     assert result_3.exit_code != 0
-    assert "Error in pipeline engine configuration structure" in result_3.stderr # Error from EngineConfig creation
+    assert (
+        "Error in pipeline engine configuration structure" in result_3.stderr
+    )  # Error from EngineConfig creation

--- a/tests/test_cli_engine.py
+++ b/tests/test_cli_engine.py
@@ -16,7 +16,7 @@ from compact_memory.engines.registry import (
 #     id = "dummy_cli_test_eng"
 # register_compression_engine(DummyTestCliEngine.id, DummyTestCliEngine)
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def _env(tmp_path: Path) -> dict[str, str]:
@@ -219,9 +219,13 @@ def test_dev_evaluate_engines_pipeline_engine(tmp_path: Path, patch_embedding_mo
     # Assuming default embedding models are used if not specified,
     # and that the test environment can handle them (e.g. mocked or tiny models).
     # This part might need adjustment if default models cause issues or if the structure is different.
-    if output_json["pipeline"]["embedding_similarity"]: # It might be empty if no models run
-        for model_name, scores in output_json["pipeline"]["embedding_similarity"].items():
+    if output_json["pipeline"][
+        "embedding_similarity"
+    ]:  # It might be empty if no models run
+        for model_name, scores in output_json["pipeline"][
+            "embedding_similarity"
+        ].items():
             assert "similarity" in scores, f"Similarity score missing for {model_name}"
-            assert abs(scores["similarity"] - 1.0) < 1e-6, ( # Allow slightly larger tolerance for embeddings
-                f"Embedding similarity for {model_name} was not 1.0: {scores['similarity']}"
-            )
+            assert (
+                abs(scores["similarity"] - 1.0) < 1e-6
+            ), f"Embedding similarity for {model_name} was not 1.0: {scores['similarity']}"  # Allow slightly larger tolerance for embeddings

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -3,11 +3,16 @@ from pathlib import Path
 from typer.testing import CliRunner
 from unittest.mock import MagicMock, patch
 from compact_memory.cli import app
-from compact_memory.validation.embedding_metrics import MultiModelEmbeddingSimilarityMetric
-# Import CompressionRatioMetric to mock its evaluate method if needed for evaluate-engines
-from compact_memory.validation.compression_metrics import CompressionRatioMetric # Corrected path
+from compact_memory.validation.embedding_metrics import (
+    MultiModelEmbeddingSimilarityMetric,
+)
 
-runner = CliRunner(mix_stderr=False)
+# Import CompressionRatioMetric to mock its evaluate method if needed for evaluate-engines
+from compact_memory.validation.compression_metrics import (
+    CompressionRatioMetric,
+)  # Corrected path
+
+runner = CliRunner()
 
 
 def _env(tmp_path: Path) -> dict[str, str]:
@@ -29,9 +34,14 @@ def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
     result = runner.invoke(
         app,
         [
-            "dev", "evaluate-compression", "hello", "hello",
-            "--metric", "embedding_similarity_multi",
-            "--metric-params", '{"model_names": ["model_a", "model_b"]}',
+            "dev",
+            "evaluate-compression",
+            "hello",
+            "hello",
+            "--metric",
+            "embedding_similarity_multi",
+            "--metric-params",
+            '{"model_names": ["model_a", "model_b"]}',
         ],
         env=_env(tmp_path),
     )
@@ -51,7 +61,8 @@ def test_evaluate_compression_cli_openai_failure(tmp_path: Path, monkeypatch):
         "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric._get_tokenizer",
         lambda s, m: mock_get_tokenizer_direct_use(m),
     )
-    tok = MagicMock(); tok.model_max_length = 8192
+    tok = MagicMock()
+    tok.model_max_length = 8192
     mock_get_tokenizer_direct_use.return_value = tok
     monkeypatch.setattr(
         "compact_memory.validation.embedding_metrics.token_utils.token_count",
@@ -60,9 +71,14 @@ def test_evaluate_compression_cli_openai_failure(tmp_path: Path, monkeypatch):
     result = runner.invoke(
         app,
         [
-            "dev", "evaluate-compression", "original text", "compressed text",
-            "--metric", "multi_model_embedding_similarity",
-            "--embedding-model", openai_model,
+            "dev",
+            "evaluate-compression",
+            "original text",
+            "compressed text",
+            "--metric",
+            "multi_model_embedding_similarity",
+            "--embedding-model",
+            openai_model,
         ],
         env=_env(tmp_path),
     )
@@ -75,8 +91,12 @@ def test_evaluate_llm_response_cli(tmp_path: Path):
     result = runner.invoke(
         app,
         [
-            "dev", "evaluate-llm-response", "hello", "hello",
-            "--metric", "exact_match",
+            "dev",
+            "evaluate-llm-response",
+            "hello",
+            "hello",
+            "--metric",
+            "exact_match",
         ],
         env=_env(tmp_path),
     )
@@ -85,50 +105,141 @@ def test_evaluate_llm_response_cli(tmp_path: Path):
 
 
 def test_evaluate_compression_multi_model_cli(tmp_path: Path, monkeypatch):
-    original_text = "original sample text"; compressed_text = "compressed sample text"
+    original_text = "original sample text"
+    compressed_text = "compressed sample text"
     metric_id = "multi_model_embedding_similarity"
     evaluate_method_path_on_class = "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric.evaluate"
 
     # Scenario 1
-    mock_data_scen1 = {"embedding_similarity": {"mock-model-1": {"similarity": 0.8, "token_count": 10}, "mock-model-2": {"similarity": 0.9, "token_count": 20}}}
+    mock_data_scen1 = {
+        "embedding_similarity": {
+            "mock-model-1": {"similarity": 0.8, "token_count": 10},
+            "mock-model-2": {"similarity": 0.9, "token_count": 20},
+        }
+    }
     mock_evaluate_scen1 = MagicMock(return_value=mock_data_scen1)
     monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen1)
-    result_scen1 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", "mock-model-1", "--embedding-model", "mock-model-2"], env=_env(tmp_path))
-    assert result_scen1.exit_code == 0, f"STDOUT: {result_scen1.stdout}\nSTDERR: {result_scen1.stderr}"
-    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen1.stdout
+    result_scen1 = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-compression",
+            original_text,
+            compressed_text,
+            "--metric",
+            metric_id,
+            "--embedding-model",
+            "mock-model-1",
+            "--embedding-model",
+            "mock-model-2",
+        ],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen1.exit_code == 0
+    ), f"STDOUT: {result_scen1.stdout}\nSTDERR: {result_scen1.stderr}"
+    assert (
+        "Scores for metric 'multi_model_embedding_similarity':" in result_scen1.stdout
+    )
     assert "- mock-model-1: similarity 0.8, tokens 10" in result_scen1.stdout
     assert "- mock-model-2: similarity 0.9, tokens 20" in result_scen1.stdout
     mock_evaluate_scen1.assert_called_once()
 
     # Scenario 2
-    mock_data_scen2 = {"embedding_similarity": {"mock-model-3": {"similarity": 0.7, "token_count": 15}, "mock-model-4": {"similarity": 0.85, "token_count": 25}}}
+    mock_data_scen2 = {
+        "embedding_similarity": {
+            "mock-model-3": {"similarity": 0.7, "token_count": 15},
+            "mock-model-4": {"similarity": 0.85, "token_count": 25},
+        }
+    }
     mock_evaluate_scen2 = MagicMock(return_value=mock_data_scen2)
     monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen2)
-    result_scen2 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", '["mock-model-3", "mock-model-4"]'], env=_env(tmp_path))
-    assert result_scen2.exit_code == 0, f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
-    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen2.stdout
+    result_scen2 = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-compression",
+            original_text,
+            compressed_text,
+            "--metric",
+            metric_id,
+            "--embedding-model",
+            '["mock-model-3", "mock-model-4"]',
+        ],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen2.exit_code == 0
+    ), f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
+    assert (
+        "Scores for metric 'multi_model_embedding_similarity':" in result_scen2.stdout
+    )
     assert "- mock-model-3: similarity 0.7, tokens 15" in result_scen2.stdout
     assert "- mock-model-4: similarity 0.85, tokens 25" in result_scen2.stdout
     mock_evaluate_scen2.assert_called_once()
 
     # Scenario 3
-    default_model_1 = "sentence-transformers/all-MiniLM-L6-v2"; default_model_2 = "sentence-transformers/all-mpnet-base-v2"
-    mock_data_scen3 = {"embedding_similarity": {default_model_1: {"similarity": 0.91, "token_count": 30}, default_model_2: {"similarity": 0.92, "token_count": 35}}}
+    default_model_1 = "sentence-transformers/all-MiniLM-L6-v2"
+    default_model_2 = "sentence-transformers/all-mpnet-base-v2"
+    mock_data_scen3 = {
+        "embedding_similarity": {
+            default_model_1: {"similarity": 0.91, "token_count": 30},
+            default_model_2: {"similarity": 0.92, "token_count": 35},
+        }
+    }
     mock_evaluate_scen3 = MagicMock(return_value=mock_data_scen3)
     monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen3)
-    result_scen3 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id], env=_env(tmp_path))
-    assert result_scen3.exit_code == 0, f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
-    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen3.stdout
+    result_scen3 = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-compression",
+            original_text,
+            compressed_text,
+            "--metric",
+            metric_id,
+        ],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen3.exit_code == 0
+    ), f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
+    assert (
+        "Scores for metric 'multi_model_embedding_similarity':" in result_scen3.stdout
+    )
     assert f"- {default_model_1}: similarity 0.91, tokens 30" in result_scen3.stdout
     assert f"- {default_model_2}: similarity 0.92, tokens 35" in result_scen3.stdout
     mock_evaluate_scen3.assert_called_once()
 
     # Scenario 4
-    mock_data_scen4 = {"embedding_similarity": {"mock-model-1": {"similarity": 0.8, "token_count": 10}, "mock-model-2": {"similarity": 0.9, "token_count": 20}}}
+    mock_data_scen4 = {
+        "embedding_similarity": {
+            "mock-model-1": {"similarity": 0.8, "token_count": 10},
+            "mock-model-2": {"similarity": 0.9, "token_count": 20},
+        }
+    }
     mock_evaluate_scen4 = MagicMock(return_value=mock_data_scen4)
     monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen4)
-    result_scen4 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", "mock-model-1", "--embedding-model", "mock-model-2", "--json"], env=_env(tmp_path))
-    assert result_scen4.exit_code == 0, f"STDOUT: {result_scen4.stdout}\nSTDERR: {result_scen4.stderr}"
+    result_scen4 = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-compression",
+            original_text,
+            compressed_text,
+            "--metric",
+            metric_id,
+            "--embedding-model",
+            "mock-model-1",
+            "--embedding-model",
+            "mock-model-2",
+            "--json",
+        ],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen4.exit_code == 0
+    ), f"STDOUT: {result_scen4.stdout}\nSTDERR: {result_scen4.stderr}"
     parsed_json_output = json.loads(result_scen4.stdout)
     assert parsed_json_output == mock_data_scen4
     mock_evaluate_scen4.assert_called_once()
@@ -148,15 +259,15 @@ def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
 
     # Mock for CompressionRatioMetric.evaluate - to prevent it from actually calculating
     # and to control its output value.
-    cr_evaluate_path = "compact_memory.validation.compression_metrics.CompressionRatioMetric.evaluate" # Corrected path
+    cr_evaluate_path = "compact_memory.validation.compression_metrics.CompressionRatioMetric.evaluate"  # Corrected path
     mock_cr_evaluate_method = MagicMock(return_value={"compression_ratio": 0.5})
     monkeypatch.setattr(cr_evaluate_path, mock_cr_evaluate_method)
 
     # Scenario 1 (was default run, now explicit): Multiple --embedding-model flags
     mock_mms_data_scen1 = {
-        "embedding_similarity": { # This is the structure MultiModelEmbeddingSimilarityMetric.evaluate returns
+        "embedding_similarity": {  # This is the structure MultiModelEmbeddingSimilarityMetric.evaluate returns
             "mock-model-1": {"similarity": 0.81, "token_count": 11},
-            "mock-model-2": {"similarity": 0.91, "token_count": 21}
+            "mock-model-2": {"similarity": 0.91, "token_count": 21},
         }
     }
     mock_mms_evaluate_method.return_value = mock_mms_data_scen1
@@ -164,26 +275,35 @@ def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
     result_scen1 = runner.invoke(
         app,
         [
-            "dev", "evaluate-engines", "--text", test_text,
-            "--engine", engine_id,
+            "dev",
+            "evaluate-engines",
+            "--text",
+            test_text,
+            "--engine",
+            engine_id,
             # No --metrics flag, it runs default metrics including MultiModel...
-            "--embedding-model", "mock-model-1",
-            "--embedding-model", "mock-model-2"
+            "--embedding-model",
+            "mock-model-1",
+            "--embedding-model",
+            "mock-model-2",
         ],
-        env=_env(tmp_path)
+        env=_env(tmp_path),
     )
     if result_scen1.exit_code != 0:
         print(f"Scenario 1 STDOUT: {result_scen1.stdout}")
         print(f"Scenario 1 STDERR: {result_scen1.stderr}")
     assert result_scen1.exit_code == 0
     mock_mms_evaluate_method.assert_called_once()
-    mock_cr_evaluate_method.assert_called_once() # Should also be called
+    mock_cr_evaluate_method.assert_called_once()  # Should also be called
 
     parsed_output_scen1 = json.loads(result_scen1.stdout)
     assert engine_id in parsed_output_scen1
     # The key in results is "embedding_similarity", not "multi_model_embedding_similarity"
     assert "embedding_similarity" in parsed_output_scen1[engine_id]
-    assert parsed_output_scen1[engine_id]["embedding_similarity"] == mock_mms_data_scen1["embedding_similarity"]
+    assert (
+        parsed_output_scen1[engine_id]["embedding_similarity"]
+        == mock_mms_data_scen1["embedding_similarity"]
+    )
     assert "compression_ratio" in parsed_output_scen1[engine_id]
     assert parsed_output_scen1[engine_id]["compression_ratio"] == 0.5
 
@@ -191,14 +311,37 @@ def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
     mock_cr_evaluate_method.reset_mock()
 
     # Scenario 2: JSON list for --embedding-model
-    mock_mms_data_scen2 = {"embedding_similarity": {"mock-model-3": {"similarity": 0.71, "token_count": 16}, "mock-model-4": {"similarity": 0.86, "token_count": 26}}}
+    mock_mms_data_scen2 = {
+        "embedding_similarity": {
+            "mock-model-3": {"similarity": 0.71, "token_count": 16},
+            "mock-model-4": {"similarity": 0.86, "token_count": 26},
+        }
+    }
     mock_mms_evaluate_method.return_value = mock_mms_data_scen2
-    result_scen2 = runner.invoke(app, ["dev", "evaluate-engines", "--text", test_text, "--engine", engine_id, "--embedding-model", '["mock-model-3", "mock-model-4"]'], env=_env(tmp_path))
-    assert result_scen2.exit_code == 0, f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
+    result_scen2 = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-engines",
+            "--text",
+            test_text,
+            "--engine",
+            engine_id,
+            "--embedding-model",
+            '["mock-model-3", "mock-model-4"]',
+        ],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen2.exit_code == 0
+    ), f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
     mock_mms_evaluate_method.assert_called_once()
     mock_cr_evaluate_method.assert_called_once()
     parsed_output_scen2 = json.loads(result_scen2.stdout)
-    assert parsed_output_scen2[engine_id]["embedding_similarity"] == mock_mms_data_scen2["embedding_similarity"]
+    assert (
+        parsed_output_scen2[engine_id]["embedding_similarity"]
+        == mock_mms_data_scen2["embedding_similarity"]
+    )
     assert parsed_output_scen2[engine_id]["compression_ratio"] == 0.5
     mock_mms_evaluate_method.reset_mock()
     mock_cr_evaluate_method.reset_mock()
@@ -206,14 +349,28 @@ def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
     # Scenario 3: Default embedding models (no --embedding-model flag)
     default_model_1 = "sentence-transformers/all-MiniLM-L6-v2"
     default_model_2 = "sentence-transformers/all-mpnet-base-v2"
-    mock_mms_data_default = {"embedding_similarity": {default_model_1: {"similarity": 0.93, "token_count": 31}, default_model_2: {"similarity": 0.94, "token_count": 36}}}
+    mock_mms_data_default = {
+        "embedding_similarity": {
+            default_model_1: {"similarity": 0.93, "token_count": 31},
+            default_model_2: {"similarity": 0.94, "token_count": 36},
+        }
+    }
     mock_mms_evaluate_method.return_value = mock_mms_data_default
-    result_scen3 = runner.invoke(app, ["dev", "evaluate-engines", "--text", test_text, "--engine", engine_id], env=_env(tmp_path))
-    assert result_scen3.exit_code == 0, f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
+    result_scen3 = runner.invoke(
+        app,
+        ["dev", "evaluate-engines", "--text", test_text, "--engine", engine_id],
+        env=_env(tmp_path),
+    )
+    assert (
+        result_scen3.exit_code == 0
+    ), f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
     mock_mms_evaluate_method.assert_called_once()
     mock_cr_evaluate_method.assert_called_once()
     parsed_output_scen3 = json.loads(result_scen3.stdout)
-    assert parsed_output_scen3[engine_id]["embedding_similarity"] == mock_mms_data_default["embedding_similarity"]
+    assert (
+        parsed_output_scen3[engine_id]["embedding_similarity"]
+        == mock_mms_data_default["embedding_similarity"]
+    )
     assert parsed_output_scen3[engine_id]["compression_ratio"] == 0.5
 
     # This part of the test (checking other metric not called) is not needed anymore


### PR DESCRIPTION
## Summary
- remove deprecated `mix_stderr` argument from `CliRunner` usage
- clean up an unused variable
- reformat tests with `black`

## Testing
- `pre-commit run --files tests/test_cli_compress.py tests/test_cli_compress_integration.py tests/test_cli_engine.py tests/test_cli_metrics.py`
- `pytest -q` *(fails: cannot unpack non-iterable CompressedMemory object)*

------
https://chatgpt.com/codex/tasks/task_e_6846576f56e48329bf886b15be1b8196