### PR TITLE
Improve FirstLastEngine decoding

### DIFF
--- a/src/compact_memory/engines/first_last_engine.py
+++ b/src/compact_memory/engines/first_last_engine.py
@@ -46,7 +46,12 @@ class FirstLastEngine(BaseCompressionEngine):
         )
 
         decode_tokenizer = tokenizer or _DEFAULT_TOKENIZER
-        tokenize_fn = _DEFAULT_TOKENIZER or (lambda t: t.split())
+        if tokenizer and (
+            hasattr(tokenizer, "encode") or hasattr(tokenizer, "tokenize")
+        ):
+            tokenize_fn = tokenizer
+        else:
+            tokenize_fn = _DEFAULT_TOKENIZER or (lambda t: t.split())
         tokens = tokenize_text(tokenize_fn, text)
 
         if llm_token_budget is None:

--- a/src/compact_memory/token_utils.py
+++ b/src/compact_memory/token_utils.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 from typing import Any, List
 
 
+class SimpleTokenizer:
+    """Fallback tokenizer that splits text on whitespace."""
+
+    def encode(self, text: str) -> List[str]:
+        """Return a list of tokens from ``text``."""
+        return text.split()
+
+    def decode(self, tokens: List[Any]) -> str:
+        """Join ``tokens`` into a string."""
+        return " ".join(str(t) for t in tokens)
+
+
 def tokenize_text(tokenizer: Any, text: str) -> List[int]:
     """Return a flat list of token ids for ``text`` using ``tokenizer``."""
     if hasattr(tokenizer, "tokenize"):
@@ -54,4 +66,4 @@ def truncate_text(tokenizer: Any, text: str, max_tokens: int) -> str:
     return " ".join(text.split()[:max_tokens])
 
 
-__all__ = ["tokenize_text", "token_count", "truncate_text"]
+__all__ = ["SimpleTokenizer", "tokenize_text", "token_count", "truncate_text"]

--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -457,12 +457,8 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     }
     """
     text_to_compress = "one two three four five six seven eight nine ten"
-    # FirstLastEngine (first_n=2, last_n=2) on "one two three four five six seven eight nine ten"
-    # Assuming space as delimiter by default if tiktoken not found.
-    # Output: "one two nine ten"
-    # With current CLI tokenization, FirstLastEngine output is based on token ids
-    # if no decode function is provided. We simply ensure the command succeeds
-    # and produces some output.
+    # FirstLastEngine receives a budget equal to the token count,
+    # so it keeps the entire text unchanged.
 
     result = runner.invoke(
         app,
@@ -481,7 +477,7 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     )
 
     assert result.exit_code == 0, f"CLI Error: {result.stderr}"
-    assert result.stdout.strip() != ""
+    assert result.stdout.strip() == text_to_compress
 
     # Another valid case: StopwordPruner -> FirstLast
     pipeline_config_json_2 = """
@@ -522,9 +518,9 @@ def test_cli_compress_pipeline_engine_valid(tmp_path: Path):
     )
 
     assert result_2.exit_code == 0, f"CLI Error: {result_2.stderr}"
-    # Output will be token ids when no decode function is provided.
-    # Ensure some output is produced.
-    assert result_2.stdout.strip() != ""
+    # Expect key words from the pruned text to remain.
+    assert "example" in result_2.stdout
+    assert "words" in result_2.stdout
 
 
 def test_cli_compress_pipeline_engine_invalid_json(tmp_path: Path):


### PR DESCRIPTION
## Summary
- use provided tokenizer for tokenization in FirstLastEngine when possible
- adjust pipeline CLI test expectations

## Testing
- `pre-commit run --files src/compact_memory/engines/first_last_engine.py tests/test_cli_compress.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cbc90da88329a424ee1fba3a334e