### PR TITLE
Refactor engine storage with VectorStore

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,9 @@ experimented with.
   tests. Embeddings are cached and normalised.
 - **`compression/pipeline_engine.py`** – implements `PipelineBaseCompressionEngine`
   allowing multiple compression steps to be chained.
+- **Compression engines** focus on text chunking and summarization but rely on
+  a pluggable `VectorStore` for storing and searching embeddings. This separation
+  lets new storage backends be introduced without altering compression logic.
 - **`chunker.py`** – implements sentence-window based chunking with token
   overlap and a fixed-size fallback. The registry allows different
   chunkers to be plugged in via config.

--- a/docs/MIGRATION_TO_ENGINES.md
+++ b/docs/MIGRATION_TO_ENGINES.md
@@ -19,13 +19,13 @@ The `MemoryContainer` class has been deprecated and its functionality is now han
 
 *   **New (using a custom engine as an example):**
     ```python
-    from compact_memory.engines import load_engine
+    from compact_memory.engines import BaseCompressionEngine
     from compact_memory.vector_store import InMemoryVectorStore
     from compact_memory.embedding_pipeline import get_embedding_dim
 
     dim = get_embedding_dim()
     store = InMemoryVectorStore(embedding_dim=dim)
-    engine = load_engine(store)
+    engine = BaseCompressionEngine(vector_store=store)
     engine.ingest("Some text")
     results = engine.recall("text")
     engine.save("my_engine_store")


### PR DESCRIPTION
## Summary
- delegate BaseCompressionEngine storage to a `VectorStore`
- update migration guide example
- document that compression engines use a pluggable vector store

## Testing
- `pre-commit run --files src/compact_memory/engines/base.py docs/MIGRATION_TO_ENGINES.md docs/ARCHITECTURE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f45660a48329b58a97998c9dd0bb