### PR TITLE
fix: ensure FirstLastEngine respects uneven budgets

### DIFF
--- a/src/compact_memory/engines/first_last_engine.py
+++ b/src/compact_memory/engines/first_last_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 import logging  # Moved import logging to top
+from math import ceil
 from typing import List, Union, Any, Optional
 
 from compact_memory.token_utils import tokenize_text
@@ -67,8 +68,12 @@ class FirstLastEngine(BaseCompressionEngine):
         elif budget <= 0:
             kept_tokens = []
         else:
-            half = max(budget // 2, 0)
-            kept_tokens = tokens[:half] + tokens[-half:]
+            token_count = len(tokens)
+            first_count = min(ceil(budget / 2), token_count)
+            last_count = max(min(budget - first_count, token_count), 0)
+            kept_tokens = list(tokens[:first_count])
+            if last_count:
+                kept_tokens += tokens[-last_count:]
 
         # Ensure decode_tokenizer is not None and has decode method
         if decode_tokenizer is not None and hasattr(decode_tokenizer, "decode"):


### PR DESCRIPTION
## Summary
- update FirstLastEngine to split budgets using ceiling math so odd budgets retain the requested number of tokens
- cap the number of first and last tokens by the available text to avoid negative or overflowing slices

## Testing
- pytest tests/test_base_engine.py::test_first_last_engine_compress_output
- pytest
- pre-commit run --files src/compact_memory/engines/first_last_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e095d818e48329b5a621fedd991035